### PR TITLE
Feat save arrays in cache

### DIFF
--- a/src/Cache/Adapter.php
+++ b/src/Cache/Adapter.php
@@ -13,8 +13,8 @@ interface Adapter
 
     /**
      * @param string $key
-     * @param string $data
-     * @return bool|string
+     * @param string|array $data
+     * @return bool|string|array
      */
     public function save($key, $data);
 

--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -39,9 +39,9 @@ class Filesystem implements Adapter
 
     /**
      * @param string $key
-     * @param string $data
+     * @param string|array $data
      * @throws \Exception
-     * @return bool|string
+     * @return bool|string|array
      */
     public function save($key, $data)
     {

--- a/src/Cache/Adapter/Memory.php
+++ b/src/Cache/Adapter/Memory.php
@@ -37,8 +37,8 @@ class Memory implements Adapter
 
     /**
      * @param string $key
-     * @param string $data
-     * @return bool|string
+     * @param string|array $data
+     * @return bool|string|array
      */
     public function save($key, $data)
     {

--- a/src/Cache/Adapter/None.php
+++ b/src/Cache/Adapter/None.php
@@ -26,8 +26,8 @@ class None implements Adapter
 
     /**
      * @param string $key
-     * @param string $data
-     * @return bool|string
+     * @param string|array $data
+     * @return bool|string|array
      */
     public function save($key, $data)
     {

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -40,8 +40,8 @@ class Redis implements Adapter
 
     /**
      * @param string $key
-     * @param string $data
-     * @return bool|string
+     * @param string|array $data
+     * @return bool|string|array
      */
     public function save($key, $data)
     {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -33,8 +33,8 @@ class Cache
      * Save data to cache. Returns data on success of false on failure.
      *
      * @param string $key
-     * @param string $data
-     * @return bool|string
+     * @param string|array $data
+     * @return bool|string|array
      */
     public function save($key, $data)
     {

--- a/tests/Cache/RedisTest.php
+++ b/tests/Cache/RedisTest.php
@@ -35,6 +35,11 @@ class RedisTest extends TestCase
      */
     protected $data = 'test data string';
 
+    /**
+     * @var array
+     */
+    protected $dataArray = ['test', 'data', 'string'];
+
     public function setUp(): void
     {
         $redis = new Redis();
@@ -58,6 +63,12 @@ class RedisTest extends TestCase
 
     public function testCacheSave()
     {
+        // test $data array
+        $result = $this->cache->save($this->key, $this->dataArray);
+
+        $this->assertEquals($this->dataArray, $result);
+
+        // test $data string
         $result = $this->cache->save($this->key, $this->data);
 
         $this->assertEquals($this->data, $result);


### PR DESCRIPTION
A cache is now a required parameter when constructing `Utopia\Database\Database`. To support document caching, the types of the `$cache->save()` method have been updated to handle arrays as well as strings.

Below is a sample warning from `psalm`:

```
INFO: InvalidArgument - src/Database/Database.php:572:48 - Argument 2 of Utopia\Cache\Cache::save expects string, array<array-key, mixed> provided (see https://psalm.dev/004)
        $this->cache->save($document->getId(), $document->getArrayCopy());
```

Test plan:
Unit tests have been expanded to check saving arrays.