### PR TITLE
Change RedisCluster timeout defaults to infinite

### DIFF
--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -52,8 +52,8 @@ class RedisCluster implements Adapter
         Client $redis,
         array $seeds,
         ?string $name = null,
-        float $timeout = 1.5,
-        float $readTimeout = 1.5,
+        float $timeout = -1,
+        float $readTimeout = -1,
         bool $persistent = false,
         string|array|null $auth = null
     ) {

--- a/tests/Cache/RedisClusterTest.php
+++ b/tests/Cache/RedisClusterTest.php
@@ -12,7 +12,7 @@ const SEEDS = [
     'redis-cluster:7002',
 ];
 
-const TIMEOUT = 1.5;
+const TIMEOUT = -1;
 
 class RedisClusterTest extends Base
 {


### PR DESCRIPTION
## Summary
- Change default `timeout` and `readTimeout` from `1.5` to `-1` (infinite) in RedisCluster adapter
- Update test case to use infinite timeout

Using infinite timeout allows cluster failovers to complete without premature connection failures. The retry mechanism handles actual failures while `-1` prevents false timeouts during slow operations.

## Test plan
- [x] Run `composer lint` and `composer format`
- [x] Run PHPUnit tests via `docker compose exec tests vendor/bin/phpunit`