### PR TITLE
Flush db vs all

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,18 @@ jobs:
           docker compose up -d
           sleep 10
 
+      - name: Wait for Hazelcast
+        run: |
+          for i in $(seq 1 30); do
+            if docker compose exec -T tests php -r "\$m = new Memcached(); \$m->addServer('hazelcast', 5701); \$s = \$m->getStats(); exit(empty(\$s) ? 1 : 0);" 2>/dev/null; then
+              echo "Hazelcast is ready"
+              exit 0
+            fi
+            echo "Waiting for Hazelcast... ($i/30)"
+            sleep 2
+          done
+          echo "Hazelcast did not become ready in time"
+          exit 1
+
       - name: Run Tests
         run: docker compose exec tests vendor/bin/phpunit --configuration phpunit.xml tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,24 +24,5 @@ jobs:
           docker compose up -d
           sleep 10
 
-      - name: Wait for Hazelcast
-        run: |
-          for i in $(seq 1 30); do
-            if docker compose exec -T tests php -r "
-              \$m = new Memcached();
-              \$m->addServer('hazelcast', 5701);
-              \$m->set('__healthcheck', '1');
-              exit(\$m->getResultCode() === Memcached::RES_SUCCESS ? 0 : 1);
-            " 2>/dev/null; then
-              echo "Hazelcast is ready"
-              exit 0
-            fi
-            echo "Waiting for Hazelcast... ($i/30)"
-            sleep 2
-          done
-          echo "Hazelcast did not become ready in time"
-          docker compose logs hazelcast 2>&1 | tail -20
-          exit 1
-
       - name: Run Tests
         run: docker compose exec tests vendor/bin/phpunit --configuration phpunit.xml tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,29 +26,21 @@ jobs:
 
       - name: Wait for Hazelcast
         run: |
-          echo "=== Hazelcast container status ==="
-          docker compose ps hazelcast
-          echo "=== Hazelcast container logs ==="
-          docker compose logs hazelcast 2>&1 | tail -50
-          echo "=== Attempting connection ==="
           for i in $(seq 1 30); do
             if docker compose exec -T tests php -r "
               \$m = new Memcached();
               \$m->addServer('hazelcast', 5701);
               \$m->set('__healthcheck', '1');
-              \$rc = \$m->getResultCode();
-              echo 'ResultCode: ' . \$rc . ' Message: ' . \$m->getResultMessage() . PHP_EOL;
-              exit(\$rc === Memcached::RES_SUCCESS ? 0 : 1);
-            "; then
+              exit(\$m->getResultCode() === Memcached::RES_SUCCESS ? 0 : 1);
+            " 2>/dev/null; then
               echo "Hazelcast is ready"
               exit 0
             fi
             echo "Waiting for Hazelcast... ($i/30)"
             sleep 2
           done
-          echo "=== Final Hazelcast logs ==="
-          docker compose logs hazelcast 2>&1 | tail -30
           echo "Hazelcast did not become ready in time"
+          docker compose logs hazelcast 2>&1 | tail -20
           exit 1
 
       - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,28 @@ jobs:
 
       - name: Wait for Hazelcast
         run: |
+          echo "=== Hazelcast container status ==="
+          docker compose ps hazelcast
+          echo "=== Hazelcast container logs ==="
+          docker compose logs hazelcast 2>&1 | tail -50
+          echo "=== Attempting connection ==="
           for i in $(seq 1 30); do
-            if docker compose exec -T tests php -r "\$m = new Memcached(); \$m->addServer('hazelcast', 5701); \$s = \$m->getStats(); exit(empty(\$s) ? 1 : 0);" 2>/dev/null; then
+            if docker compose exec -T tests php -r "
+              \$m = new Memcached();
+              \$m->addServer('hazelcast', 5701);
+              \$m->set('__healthcheck', '1');
+              \$rc = \$m->getResultCode();
+              echo 'ResultCode: ' . \$rc . ' Message: ' . \$m->getResultMessage() . PHP_EOL;
+              exit(\$rc === Memcached::RES_SUCCESS ? 0 : 1);
+            "; then
               echo "Hazelcast is ready"
               exit 0
             fi
             echo "Waiting for Hazelcast... ($i/30)"
             sleep 2
           done
+          echo "=== Final Hazelcast logs ==="
+          docker compose logs hazelcast 2>&1 | tail -30
           echo "Hazelcast did not become ready in time"
           exit 1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - database
 
   hazelcast:
-    image: hazelcast/hazelcast:5.1.3
+    image: hazelcast/hazelcast:5.3.7
     environment:
       HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED: "true"
     container_name: hazelcast

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -38,6 +38,8 @@ class Redis implements Adapter
      */
     private bool $persistent = false;
 
+    private int $dbIndex = 0;
+
     /**
      * Redis constructor.
      *
@@ -45,7 +47,6 @@ class Redis implements Adapter
      */
     public function __construct(Client $redis)
     {
-        // On connection loss, RedisClient loses the connection info. So we need to store the connection info.
         $this->host = $redis->getHost();
         $this->port = $redis->getPort();
         $timeout = $redis->getTimeout();
@@ -53,8 +54,8 @@ class Redis implements Adapter
         $this->persistentId = $redis->getPersistentId();
         $this->readTimeout = $redis->getReadTimeout();
 
-        // Detect if the connection was persistent (pconnect sets a persistentId)
         $this->persistent = $this->persistentId !== null;
+        $this->dbIndex = $redis->getDbNum();
 
         if (! empty($redis->getAuth())) {
             $this->auth = $redis->getAuth();
@@ -186,7 +187,7 @@ class Redis implements Adapter
      */
     public function flush(): bool
     {
-        return (bool) $this->execute(fn () => $this->redis->flushAll());
+        return (bool) $this->execute(fn () => $this->redis->flushDB());
     }
 
     /**
@@ -329,13 +330,13 @@ class Redis implements Adapter
             $newRedis->auth($this->auth);
         }
 
+        if ($this->dbIndex !== 0) {
+            $newRedis->select($this->dbIndex);
+        }
+
         $this->redis = $newRedis;
     }
 
-    /**
-     * @param  string|null  $key
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         return 'redis';

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -187,8 +187,10 @@ class RedisCluster implements Adapter
     public function flush(): bool
     {
         return (bool) $this->execute(function () {
-            foreach ($this->redis->_masters() as $master) {
-                $this->redis->flushAll($master);
+            /** @var array<string> $masters */
+            $masters = $this->redis->_masters();
+            foreach ($masters as $master) {
+                $this->redis->flushDB($master);
             }
 
             return true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redis connections now preserve the selected database when reconnecting.
  * Cache flush now targets the selected database instead of flushing all databases cluster-wide.

* **Tests**
  * CI workflow adds a readiness wait for the cache service before running tests to improve reliability.

* **Chores**
  * Bumped Hazelcast image used in the local/test compose setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->