### PR TITLE
feat: add getter methods to cache adapters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpunit/phpunit": "^9.3",
         "vimeo/psalm": "4.13.1",
         "phpstan/phpstan": "^1.12",
-        "laravel/pint": "1.2.*"
+        "laravel/pint": "^1.29"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d33703ed3a1dc42fb598493d1eae8d90",
+    "content-hash": "1349ac79fa891e620ecc824e52b0d563",
     "packages": [
         {
             "name": "brick/math",
@@ -2599,16 +2599,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.2.1",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "e60e2112ee779ce60f253695b273d1646a17d6f1"
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/e60e2112ee779ce60f253695b273d1646a17d6f1",
-                "reference": "e60e2112ee779ce60f253695b273d1646a17d6f1",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/bdec963f53172c5e36330f3a400604c69bf02d39",
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39",
                 "shasum": ""
             },
             "require": {
@@ -2616,16 +2616,17 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.0"
+                "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.11.0",
-                "illuminate/view": "^9.32.0",
-                "laravel-zero/framework": "^9.2.0",
-                "mockery/mockery": "^1.5.1",
-                "nunomaduro/larastan": "^2.2.0",
-                "nunomaduro/termwind": "^1.14.0",
-                "pestphp/pest": "^1.22.1"
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "illuminate/view": "^12.54.1",
+                "larastan/larastan": "^3.9.3",
+                "laravel-zero/framework": "^12.0.5",
+                "mockery/mockery": "^1.6.12",
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.0"
             },
             "bin": [
                 "builds/pint"
@@ -2651,6 +2652,7 @@
             "description": "An opinionated code formatter for PHP.",
             "homepage": "https://laravel.com",
             "keywords": [
+                "dev",
                 "format",
                 "formatter",
                 "lint",
@@ -2661,7 +2663,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2022-11-29T16:25:20+00:00"
+            "time": "2026-03-12T15:51:39+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -5419,7 +5421,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5429,5 +5431,5 @@
         "ext-memcached": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Cache/Adapter.php
+++ b/src/Cache/Adapter.php
@@ -9,74 +9,47 @@ interface Adapter
     const MAX_RETRIES = 10;
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl time in seconds
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  int  $ttl  time in seconds
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed;
 
     /**
-     * @param  string  $key
      * @param  string|array<int|string, mixed>  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array;
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array;
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool;
 
-    /**
-     * @return bool
-     */
     public function flush(): bool;
 
-    /**
-     * @return bool
-     */
     public function ping(): bool;
 
-    /**
-     * @return int
-     */
     public function getSize(): int;
 
-    /**
-     * @param  string|null  $key
-     * @return string
-     */
     public function getName(?string $key = null): string;
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self;
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self;
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int;
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int;
 }

--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -20,7 +20,7 @@ class Filesystem implements Adapter
         $this->path = $path;
     }
 
-    public function getPath(): string
+    public function getBasePath(): string
     {
         return $this->path;
     }

--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -23,6 +23,14 @@ class Filesystem implements Adapter
     }
 
     /**
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
      * @param  int  $maxRetries (0-10)
      * @return self
      */

--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -14,25 +14,19 @@ class Filesystem implements Adapter
 
     /**
      * Filesystem constructor.
-     *
-     * @param  string  $path
      */
     public function __construct(string $path)
     {
         $this->path = $path;
     }
 
-    /**
-     * @return string
-     */
     public function getPath(): string
     {
         return $this->path;
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -40,8 +34,7 @@ class Filesystem implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -49,10 +42,8 @@ class Filesystem implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl time in seconds
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  int  $ttl  time in seconds
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -66,9 +57,8 @@ class Filesystem implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      *
      * @throws Exception
@@ -95,7 +85,6 @@ class Filesystem implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -104,9 +93,7 @@ class Filesystem implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
@@ -119,17 +106,11 @@ class Filesystem implements Adapter
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function flush(): bool
     {
         return $this->deleteDirectory($this->path);
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         return file_exists($this->path) && is_writable($this->path) && is_readable($this->path);
@@ -137,8 +118,6 @@ class Filesystem implements Adapter
 
     /**
      * Returning root directory size in bytes
-     *
-     * @return int
      */
     public function getSize(): int
     {
@@ -149,10 +128,6 @@ class Filesystem implements Adapter
         }
     }
 
-    /**
-     * @param  string  $dir
-     * @return int
-     */
     private function getDirectorySize(string $dir): int
     {
         $size = 0;
@@ -175,19 +150,12 @@ class Filesystem implements Adapter
         return $size;
     }
 
-    /**
-     * @param  string  $filename
-     * @return string
-     */
     public function getPath(string $filename): string
     {
         return $this->path.DIRECTORY_SEPARATOR.$filename;
     }
 
     /**
-     * @param  string  $path
-     * @return bool
-     *
      * @throws Exception
      */
     protected function deleteDirectory(string $path): bool
@@ -217,26 +185,16 @@ class Filesystem implements Adapter
         return rmdir($path);
     }
 
-    /**
-     * @param  string|null  $key
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         return 'filesystem';
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return 0;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return 1000;

--- a/src/Cache/Adapter/Hazelcast.php
+++ b/src/Cache/Adapter/Hazelcast.php
@@ -7,9 +7,6 @@ use Utopia\Cache\Adapter;
 
 class Hazelcast implements Adapter
 {
-    /**
-     * @var Client
-     */
     protected Client $memcached;
 
     private int $maxRetries = 0;
@@ -21,17 +18,13 @@ class Hazelcast implements Adapter
         $this->memcached = $memcached;
     }
 
-    /**
-     * @return Client
-     */
     public function getClient(): Client
     {
         return $this->memcached;
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -41,8 +34,7 @@ class Hazelcast implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -52,10 +44,8 @@ class Hazelcast implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl time in seconds
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  int  $ttl  time in seconds
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -68,7 +58,7 @@ class Hazelcast implements Adapter
             return false;
         }
 
-        if (($cache['time'] + $ttl > time())) { // Cache is valid
+        if ((time() < $cache['time'] + $ttl)) { // Cache is valid
             return $cache['data'];
         }
 
@@ -76,9 +66,8 @@ class Hazelcast implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -96,7 +85,6 @@ class Hazelcast implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -105,9 +93,7 @@ class Hazelcast implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
@@ -116,16 +102,13 @@ class Hazelcast implements Adapter
 
     /**
      * @return bool
-     * currently hazelcast doesn't support flush functionality, so returning false in that case
+     *              currently hazelcast doesn't support flush functionality, so returning false in that case
      */
     public function flush(): bool
     {
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         try {
@@ -139,8 +122,6 @@ class Hazelcast implements Adapter
 
     /**
      * Returning total number of keys
-     *
-     * @return int
      */
     public function getSize(): int
     {
@@ -157,25 +138,16 @@ class Hazelcast implements Adapter
         return $size;
     }
 
-    /**
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         return 'hazelcast';
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return $this->maxRetries;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return $this->retryDelay;
@@ -184,7 +156,7 @@ class Hazelcast implements Adapter
     /**
      * Execute a Memcached command with retry logic
      *
-     * @param  callable  $callback The Memcached operation to execute
+     * @param  callable  $callback  The Memcached operation to execute
      * @return mixed The result of the Memcached operation
      *
      * @throws \MemcachedException When all retry attempts fail
@@ -198,16 +170,16 @@ class Hazelcast implements Adapter
             $result = $callback();
 
             if ($result === false && in_array($this->memcached->getResultCode(), [
-                \Memcached::RES_HOST_LOOKUP_FAILURE,
-                \Memcached::RES_UNKNOWN_READ_FAILURE,
-                \Memcached::RES_WRITE_FAILURE,
-                \Memcached::RES_PROTOCOL_ERROR,
-                \Memcached::RES_INVALID_HOST_PROTOCOL,
-                \Memcached::RES_CONNECTION_SOCKET_CREATE_FAILURE,
-                \Memcached::RES_CONNECTION_FAILURE,
-                \Memcached::RES_SERVER_TEMPORARILY_DISABLED,
-                \Memcached::RES_SERVER_MARKED_DEAD,
-                \Memcached::RES_TIMEOUT,
+                Client::RES_HOST_LOOKUP_FAILURE,
+                Client::RES_UNKNOWN_READ_FAILURE,
+                Client::RES_WRITE_FAILURE,
+                Client::RES_PROTOCOL_ERROR,
+                Client::RES_INVALID_HOST_PROTOCOL,
+                Client::RES_CONNECTION_SOCKET_CREATE_FAILURE,
+                Client::RES_CONNECTION_FAILURE,
+                Client::RES_SERVER_TEMPORARILY_DISABLED,
+                Client::RES_SERVER_MARKED_DEAD,
+                Client::RES_TIMEOUT,
             ])) {
                 $attempts++;
 

--- a/src/Cache/Adapter/Hazelcast.php
+++ b/src/Cache/Adapter/Hazelcast.php
@@ -22,6 +22,14 @@ class Hazelcast implements Adapter
     }
 
     /**
+     * @return Client
+     */
+    public function getClient(): Client
+    {
+        return $this->memcached;
+    }
+
+    /**
      * @param  int  $maxRetries (0-10)
      * @return self
      */

--- a/src/Cache/Adapter/Memcached.php
+++ b/src/Cache/Adapter/Memcached.php
@@ -27,6 +27,14 @@ class Memcached implements Adapter
     }
 
     /**
+     * @return Client
+     */
+    public function getClient(): Client
+    {
+        return $this->memcached;
+    }
+
+    /**
      * @param  int  $maxRetries (0-10)
      * @return self
      */

--- a/src/Cache/Adapter/Memcached.php
+++ b/src/Cache/Adapter/Memcached.php
@@ -7,9 +7,6 @@ use Utopia\Cache\Adapter;
 
 class Memcached implements Adapter
 {
-    /**
-     * @var Client
-     */
     protected Client $memcached;
 
     private int $maxRetries = 0;
@@ -18,25 +15,19 @@ class Memcached implements Adapter
 
     /**
      * Memcached constructor.
-     *
-     * @param  Client  $memcached
      */
     public function __construct(Client $memcached)
     {
         $this->memcached = $memcached;
     }
 
-    /**
-     * @return Client
-     */
     public function getClient(): Client
     {
         return $this->memcached;
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -46,8 +37,7 @@ class Memcached implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -57,10 +47,7 @@ class Memcached implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -70,7 +57,7 @@ class Memcached implements Adapter
             return false;
         }
 
-        if ($cache['time'] + $ttl > time()) { // Cache is valid
+        if (time() < $cache['time'] + $ttl) { // Cache is valid
             return $cache['data'];
         }
 
@@ -78,9 +65,8 @@ class Memcached implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -98,7 +84,6 @@ class Memcached implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -107,26 +92,18 @@ class Memcached implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
         return (bool) $this->execute(fn () => $this->memcached->delete($key));
     }
 
-    /**
-     * @return bool
-     */
     public function flush(): bool
     {
         return (bool) $this->execute(fn () => $this->memcached->flush());
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         try {
@@ -140,8 +117,6 @@ class Memcached implements Adapter
 
     /**
      * Returning total number of keys
-     *
-     * @return int
      */
     public function getSize(): int
     {
@@ -158,26 +133,16 @@ class Memcached implements Adapter
         return $size;
     }
 
-    /**
-     * @param  string|null  $key
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         return 'memcached';
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return $this->maxRetries;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return $this->retryDelay;
@@ -186,7 +151,7 @@ class Memcached implements Adapter
     /**
      * Execute a Memcached command with retry logic
      *
-     * @param  callable  $callback The Memcached operation to execute
+     * @param  callable  $callback  The Memcached operation to execute
      * @return mixed The result of the Memcached operation
      *
      * @throws \MemcachedException When all retry attempts fail
@@ -200,16 +165,16 @@ class Memcached implements Adapter
             $result = $callback();
 
             if ($result === false && in_array($this->memcached->getResultCode(), [
-                \Memcached::RES_HOST_LOOKUP_FAILURE,
-                \Memcached::RES_UNKNOWN_READ_FAILURE,
-                \Memcached::RES_WRITE_FAILURE,
-                \Memcached::RES_PROTOCOL_ERROR,
-                \Memcached::RES_INVALID_HOST_PROTOCOL,
-                \Memcached::RES_CONNECTION_SOCKET_CREATE_FAILURE,
-                \Memcached::RES_CONNECTION_FAILURE,
-                \Memcached::RES_SERVER_TEMPORARILY_DISABLED,
-                \Memcached::RES_SERVER_MARKED_DEAD,
-                \Memcached::RES_TIMEOUT,
+                Client::RES_HOST_LOOKUP_FAILURE,
+                Client::RES_UNKNOWN_READ_FAILURE,
+                Client::RES_WRITE_FAILURE,
+                Client::RES_PROTOCOL_ERROR,
+                Client::RES_INVALID_HOST_PROTOCOL,
+                Client::RES_CONNECTION_SOCKET_CREATE_FAILURE,
+                Client::RES_CONNECTION_FAILURE,
+                Client::RES_SERVER_TEMPORARILY_DISABLED,
+                Client::RES_SERVER_MARKED_DEAD,
+                Client::RES_TIMEOUT,
             ])) {
                 $attempts++;
 

--- a/src/Cache/Adapter/Memory.php
+++ b/src/Cache/Adapter/Memory.php
@@ -14,13 +14,10 @@ class Memory implements Adapter
     /**
      * Memory constructor.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -28,8 +25,7 @@ class Memory implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -37,10 +33,7 @@ class Memory implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -48,16 +41,15 @@ class Memory implements Adapter
             /** @var array{time: int, data: string} */
             $saved = $this->store[$key];
 
-            return ($saved['time'] + $ttl > time()) ? $saved['data'] : false; // return data if cache is valid
+            return (time() < $saved['time'] + $ttl) ? $saved['data'] : false; // return data if cache is valid
         }
 
         return false;
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -77,7 +69,6 @@ class Memory implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -86,9 +77,7 @@ class Memory implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
@@ -101,9 +90,6 @@ class Memory implements Adapter
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function flush(): bool
     {
         $this->store = [];
@@ -111,9 +97,6 @@ class Memory implements Adapter
         return true;
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         return true;
@@ -121,34 +104,22 @@ class Memory implements Adapter
 
     /**
      * Returning total number of keys
-     *
-     * @return int
      */
     public function getSize(): int
     {
         return count($this->store);
     }
 
-    /**
-     * @param  string|null  $key
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         return 'memory';
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return 0;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return 0;

--- a/src/Cache/Adapter/None.php
+++ b/src/Cache/Adapter/None.php
@@ -9,13 +9,10 @@ class None implements Adapter
     /**
      * None constructor.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -23,8 +20,7 @@ class None implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -32,10 +28,7 @@ class None implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -43,9 +36,8 @@ class None implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -54,7 +46,6 @@ class None implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -63,59 +54,38 @@ class None implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
         return true;
     }
 
-    /**
-     * @return bool
-     */
     public function flush(): bool
     {
         return true;
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         return true;
     }
 
-    /**
-     * @return int
-     */
     public function getSize(): int
     {
         return 0;
     }
 
-    /**
-     * @param  string|null  $key
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         return 'none';
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return 0;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return 0;

--- a/src/Cache/Adapter/Pool.php
+++ b/src/Cache/Adapter/Pool.php
@@ -29,6 +29,14 @@ class Pool implements Adapter
     }
 
     /**
+     * @return UtopiaPool<covariant Adapter>
+     */
+    public function getPool(): UtopiaPool
+    {
+        return $this->pool;
+    }
+
+    /**
      * Forward method calls to the internal adapter instance via the pool.
      *
      * Required because __call() can't be used to implement abstract methods.

--- a/src/Cache/Adapter/Pool.php
+++ b/src/Cache/Adapter/Pool.php
@@ -13,7 +13,7 @@ class Pool implements Adapter
     protected UtopiaPool $pool;
 
     /**
-     * @param  UtopiaPool<covariant Adapter>  $pool The pool to use for connections. Must contain instances of Adapter.
+     * @param  UtopiaPool<covariant Adapter>  $pool  The pool to use for connections. Must contain instances of Adapter.
      *
      * @throws \Exception
      */
@@ -41,9 +41,7 @@ class Pool implements Adapter
      *
      * Required because __call() can't be used to implement abstract methods.
      *
-     * @param  string  $method
      * @param  array<mixed>  $args
-     * @return mixed
      */
     public function delegate(string $method, array $args): mixed
     {

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -65,6 +65,14 @@ class Redis implements Adapter
     }
 
     /**
+     * @return Client
+     */
+    public function getClient(): Client
+    {
+        return $this->redis;
+    }
+
+    /**
      * @param  int  $maxRetries (0-10)
      * @return self
      */

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -9,9 +9,6 @@ use Utopia\Cache\Adapter;
 
 class Redis implements Adapter
 {
-    /**
-     * @var Client
-     */
     protected Client $redis;
 
     private int $maxRetries = 0;
@@ -42,8 +39,6 @@ class Redis implements Adapter
 
     /**
      * Redis constructor.
-     *
-     * @param  Client  $redis
      */
     public function __construct(Client $redis)
     {
@@ -64,17 +59,13 @@ class Redis implements Adapter
         $this->redis = $redis;
     }
 
-    /**
-     * @return Client
-     */
     public function getClient(): Client
     {
         return $this->redis;
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -84,8 +75,7 @@ class Redis implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -95,10 +85,8 @@ class Redis implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl time in seconds
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  int  $ttl  time in seconds
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -119,7 +107,7 @@ class Redis implements Adapter
         /** @var array{time: int, data: string} */
         $cache = json_decode($redis_string, true);
 
-        if ($cache['time'] + $ttl > time()) { // Cache is valid
+        if (time() < $cache['time'] + $ttl) { // Cache is valid
             return $cache['data'];
         }
 
@@ -127,9 +115,8 @@ class Redis implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -147,7 +134,7 @@ class Redis implements Adapter
                 'time' => \time(),
                 'data' => $data,
             ], flags: JSON_THROW_ON_ERROR);
-        } catch(Throwable $th) {
+        } catch (Throwable $th) {
             return false;
         }
 
@@ -161,7 +148,6 @@ class Redis implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -177,9 +163,7 @@ class Redis implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
@@ -190,17 +174,11 @@ class Redis implements Adapter
         return (bool) $this->execute(fn () => $this->redis->del($key));
     }
 
-    /**
-     * @return bool
-     */
     public function flush(): bool
     {
         return (bool) $this->execute(fn () => $this->redis->flushDB());
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         try {
@@ -214,8 +192,6 @@ class Redis implements Adapter
 
     /**
      * Returning total number of keys
-     *
-     * @return int
      */
     public function getSize(): int
     {
@@ -225,17 +201,11 @@ class Redis implements Adapter
         return $size;
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return $this->maxRetries;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return $this->retryDelay;
@@ -244,8 +214,6 @@ class Redis implements Adapter
     /**
      * Execute a Redis command with retry logic
      *
-     * @param  callable  $callback
-     * @return mixed
      *
      * @throws \RedisException
      */
@@ -287,9 +255,6 @@ class Redis implements Adapter
      *
      * RedisException always returns error code 0 with no subclasses for different error types.
      * The only way to differentiate connection errors from command errors is by message matching.
-     *
-     * @param  Exception  $e
-     * @return bool
      */
     private function isConnectionError(Exception $e): bool
     {
@@ -312,7 +277,7 @@ class Redis implements Adapter
 
     private function reconnect(): void
     {
-        $newRedis = new Client();
+        $newRedis = new Client;
 
         if ($this->persistent) {
             $newRedis->pconnect(

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -67,6 +67,14 @@ class RedisCluster implements Adapter
     }
 
     /**
+     * @return Client
+     */
+    public function getClient(): Client
+    {
+        return $this->redis;
+    }
+
+    /**
      * @param  int  $maxRetries (0-10)
      * @return self
      */

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -9,9 +9,6 @@ use Utopia\Cache\Adapter;
 
 class RedisCluster implements Adapter
 {
-    /**
-     * @var Client
-     */
     protected Client $redis;
 
     /**
@@ -19,9 +16,6 @@ class RedisCluster implements Adapter
      */
     protected array $seeds;
 
-    /**
-     * @var ?string
-     */
     protected ?string $name;
 
     private int $maxRetries = 0;
@@ -40,12 +34,7 @@ class RedisCluster implements Adapter
     private string|array|null $auth;
 
     /**
-     * @param  Client  $redis
      * @param  array<string>  $seeds
-     * @param  string|null  $name
-     * @param  float  $timeout
-     * @param  float  $readTimeout
-     * @param  bool  $persistent
      * @param  string|array<string>|null  $auth  Password string or ['username', 'password'] array for ACL
      */
     public function __construct(
@@ -66,17 +55,13 @@ class RedisCluster implements Adapter
         $this->auth = $auth;
     }
 
-    /**
-     * @return Client
-     */
     public function getClient(): Client
     {
         return $this->redis;
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -86,8 +71,7 @@ class RedisCluster implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -97,10 +81,8 @@ class RedisCluster implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl time in seconds
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  int  $ttl  time in seconds
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -118,7 +100,7 @@ class RedisCluster implements Adapter
         /** @var array{time: int, data: string} $cache */
         $cache = json_decode($redis_string, true);
 
-        if ($cache['time'] + $ttl > time()) { // Cache is valid
+        if (time() < $cache['time'] + $ttl) { // Cache is valid
             return $cache['data'];
         }
 
@@ -126,9 +108,8 @@ class RedisCluster implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -160,7 +141,6 @@ class RedisCluster implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -176,9 +156,7 @@ class RedisCluster implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
@@ -189,9 +167,6 @@ class RedisCluster implements Adapter
         return (bool) $this->execute(fn () => $this->redis->del($key));
     }
 
-    /**
-     * @return bool
-     */
     public function flush(): bool
     {
         return (bool) $this->execute(function () {
@@ -205,9 +180,6 @@ class RedisCluster implements Adapter
         });
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         try {
@@ -225,8 +197,6 @@ class RedisCluster implements Adapter
 
     /**
      * Returning total number of keys
-     *
-     * @return int
      */
     public function getSize(): int
     {
@@ -246,25 +216,16 @@ class RedisCluster implements Adapter
         return (int) $size;
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return $this->maxRetries;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return $this->retryDelay;
     }
 
-    /**
-     * @return ?string
-     */
     public function getClusterName(): ?string
     {
         return $this->name;
@@ -281,8 +242,6 @@ class RedisCluster implements Adapter
     /**
      * Execute a Redis command with retry logic
      *
-     * @param  callable  $callback
-     * @return mixed
      *
      * @throws \RedisClusterException
      */
@@ -324,9 +283,6 @@ class RedisCluster implements Adapter
      *
      * RedisClusterException always returns error code 0 with no subclasses for different error types.
      * The only way to differentiate connection errors from command errors is by message matching.
-     *
-     * @param  Exception  $e
-     * @return bool
      */
     private function isConnectionError(Exception $e): bool
     {
@@ -366,10 +322,6 @@ class RedisCluster implements Adapter
         $this->redis = $newRedis;
     }
 
-    /**
-     * @param  string|null  $key
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         return 'redis-cluster';

--- a/src/Cache/Adapter/Sharding.php
+++ b/src/Cache/Adapter/Sharding.php
@@ -45,6 +45,14 @@ class Sharding implements Adapter
     }
 
     /**
+     * @return Adapter[]
+     */
+    public function getAdapters(): array
+    {
+        return $this->adapters;
+    }
+
+    /**
      * @param  int  $maxRetries (0-10)
      * @return self
      */

--- a/src/Cache/Adapter/Sharding.php
+++ b/src/Cache/Adapter/Sharding.php
@@ -11,9 +11,6 @@ class Sharding implements Adapter
      */
     protected array $adapters;
 
-    /**
-     * @var int
-     */
     protected int $count = 0;
 
     /**
@@ -53,8 +50,7 @@ class Sharding implements Adapter
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
+     * @param  int  $maxRetries  (0-10)
      */
     public function setMaxRetries(int $maxRetries): self
     {
@@ -66,8 +62,7 @@ class Sharding implements Adapter
     }
 
     /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
+     * @param  int  $retryDelay  time in milliseconds
      */
     public function setRetryDelay(int $retryDelay): self
     {
@@ -79,10 +74,8 @@ class Sharding implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  int  $ttl time in seconds
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  int  $ttl  time in seconds
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -90,9 +83,8 @@ class Sharding implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -101,7 +93,6 @@ class Sharding implements Adapter
     }
 
     /**
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -110,18 +101,13 @@ class Sharding implements Adapter
     }
 
     /**
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
         return $this->getAdapter($key)->purge($key, $hash);
     }
 
-    /**
-     * @return bool
-     */
     public function flush(): bool
     {
         $result = true;
@@ -132,9 +118,6 @@ class Sharding implements Adapter
         return $result;
     }
 
-    /**
-     * @return bool
-     */
     public function ping(): bool
     {
         foreach ($this->adapters as $value) {
@@ -148,8 +131,6 @@ class Sharding implements Adapter
 
     /**
      * Returning total number of keys of all adapters
-     *
-     * @return int
      */
     public function getSize(): int
     {
@@ -161,9 +142,6 @@ class Sharding implements Adapter
         return $size;
     }
 
-    /**
-     * @return string
-     */
     public function getName(?string $key = null): string
     {
         if ($key === null) {
@@ -173,10 +151,6 @@ class Sharding implements Adapter
         return $this->getAdapter($key)->getName();
     }
 
-    /**
-     * @param  string  $key
-     * @return Adapter
-     */
     protected function getAdapter(string $key): Adapter
     {
         $hash = \crc32($key);
@@ -185,17 +159,11 @@ class Sharding implements Adapter
         return $this->adapters[$index];
     }
 
-    /**
-     * @return int
-     */
     public function getMaxRetries(): int
     {
         return 0;
     }
 
-    /**
-     * @return int
-     */
     public function getRetryDelay(): int
     {
         return 0;

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -15,15 +15,10 @@ class Cache
      */
     public bool $caseSensitive = false;
 
-    /**
-     * @var Histogram|null
-     */
     protected ?Histogram $operationDuration = null;
 
     /**
      * Set telemetry adapter and create histograms for cache operations.
-     *
-     * @param  Telemetry  $telemetry
      */
     public function setTelemetry(Telemetry $telemetry): void
     {
@@ -37,20 +32,17 @@ class Cache
 
     /**
      * Initialize with a no-op telemetry adapter by default.
-     *
-     * @param  Adapter  $adapter
      */
     public function __construct(Adapter $adapter)
     {
         $this->adapter = $adapter;
-        $this->setTelemetry(new NoTelemetry());
+        $this->setTelemetry(new NoTelemetry);
     }
 
     /**
      * Toggle case sensitivity of keys inside cache
      *
-     * @param  bool  $value if true, cache keys will be case-sensitive
-     * @return bool
+     * @param  bool  $value  if true, cache keys will be case-sensitive
      */
     public function setCaseSensitivity(bool $value): bool
     {
@@ -60,10 +52,8 @@ class Cache
     /**
      * Load cached data. return false in no valid cache.
      *
-     * @param  string  $key
-     * @param  int  $ttl time in seconds
-     * @param  string  $hash optional
-     * @return mixed
+     * @param  int  $ttl  time in seconds
+     * @param  string  $hash  optional
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
@@ -84,9 +74,8 @@ class Cache
     /**
      * Save data to cache. Returns data on success of false on failure.
      *
-     * @param  string  $key
      * @param  string|array<int|string, mixed>  $data
-     * @param  string  $hash optional
+     * @param  string  $hash  optional
      * @return bool|string|array<int|string, mixed>
      */
     public function save(string $key, mixed $data, string $hash = ''): bool|string|array
@@ -109,7 +98,6 @@ class Cache
     /**
      * Returns a list of keys.
      *
-     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array
@@ -130,9 +118,7 @@ class Cache
     /**
      * Removes data from cache. Returns true on success of false on failure.
      *
-     * @param  string  $key
-     * @param  string  $hash optional
-     * @return bool
+     * @param  string  $hash  optional
      */
     public function purge(string $key, string $hash = ''): bool
     {
@@ -152,8 +138,6 @@ class Cache
 
     /**
      * Removes all data from cache. Returns true on success of false on failure.
-     *
-     * @return bool
      */
     public function flush(): bool
     {
@@ -170,8 +154,6 @@ class Cache
 
     /**
      * Check Cache Connecitivity
-     *
-     * @return bool
      */
     public function ping(): bool
     {
@@ -180,8 +162,6 @@ class Cache
 
     /**
      * Get db size.
-     *
-     * @return int
      */
     public function getSize(): int
     {

--- a/tests/Cache/Base.php
+++ b/tests/Cache/Base.php
@@ -22,7 +22,7 @@ abstract class Base extends TestCase
      * General tests
      * Can be overwritten in a specific adapter if required, such as None cache
      */
-    public function testCacheSave(): void
+    public function test_cache_save(): void
     {
         // test $data array
         $result = self::$cache->save($this->key, $this->dataArray, $this->key);
@@ -35,14 +35,14 @@ abstract class Base extends TestCase
         $this->assertEquals($this->data, $result);
     }
 
-    public function testNotEmptyCacheKey(): void
+    public function test_not_empty_cache_key(): void
     {
         $data = self::$cache->load($this->key, 60 * 60 * 24 * 30 * 3 /* 3 months */, $this->key);
 
         $this->assertEquals($this->data, $data);
     }
 
-    public function testCachePurge(): void
+    public function test_cache_purge(): void
     {
         $data = self::$cache->load($this->key, 60 * 60 * 24 * 30 * 3 /* 3 months */, $this->key);
 
@@ -57,7 +57,7 @@ abstract class Base extends TestCase
         $this->assertEquals(false, $data);
     }
 
-    public function testCaseInsensitivity(): void
+    public function test_case_insensitivity(): void
     {
         // Ensure case in-sensitivity first (configured in adapter's setUp)
         $data = self::$cache->save('planet', 'Earth', 'planet');
@@ -92,12 +92,12 @@ abstract class Base extends TestCase
         $this->assertEquals(true, $result);
     }
 
-    public function testPing(): void
+    public function test_ping(): void
     {
         $this->assertEquals(true, self::$cache->ping());
     }
 
-    public function testFlush(): void
+    public function test_flush(): void
     {
         $result1 = self::$cache->save('x', 'x', 'x');
         $result2 = self::$cache->save('y', 'y', 'y');

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -17,7 +17,7 @@ class FilesystemTest extends Base
         self::$cache = new Cache(new Filesystem($path));
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         self::$cache->save('test', 'test');
         $this->assertEquals(4, self::$cache->getSize());

--- a/tests/Cache/HazelcastTest.php
+++ b/tests/Cache/HazelcastTest.php
@@ -2,7 +2,7 @@
 
 namespace Utopia\Tests;
 
-use Memcached as Memcached;
+use Memcached;
 use Utopia\Cache\Adapter\Hazelcast as HazelcastAdapter;
 use Utopia\Cache\Cache;
 
@@ -10,19 +10,19 @@ class HazelcastTest extends Base
 {
     public static function setUpBeforeClass(): void
     {
-        $memcached = new Memcached();
+        $memcached = new Memcached;
         $memcached->addServer('hazelcast', 5701);
         self::$cache = new Cache(new HazelcastAdapter($memcached));
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         $this->assertEquals(0, self::$cache->getSize());
     }
 
-    public function testCacheReconnect(): void
+    public function test_cache_reconnect(): void
     {
-        $memcached = new Memcached();
+        $memcached = new Memcached;
         $memcached->addServer('hazelcast', 5701);
         self::$cache = new Cache((new HazelcastAdapter($memcached))->setMaxRetries(3));
         self::$cache->save('test:reconnect', 'reconnect', 'test:reconnect');
@@ -48,9 +48,9 @@ class HazelcastTest extends Base
         $this->assertEquals('reconnect', self::$cache->load('test:reconnect', 5));
     }
 
-    public function testFlush(): void
+    public function test_flush(): void
     {
-        //not implemented as Hazelcast doesn't support flush functionality
+        // not implemented as Hazelcast doesn't support flush functionality
         $result = self::$cache->flush();
 
         $this->assertEquals(false, $result);

--- a/tests/Cache/MemcachedTest.php
+++ b/tests/Cache/MemcachedTest.php
@@ -2,7 +2,7 @@
 
 namespace Utopia\Tests;
 
-use Memcached as Memcached;
+use Memcached;
 use Utopia\Cache\Adapter\Memcached as MemcachedAdapter;
 use Utopia\Cache\Cache;
 
@@ -10,21 +10,21 @@ class MemcachedTest extends Base
 {
     public static function setUpBeforeClass(): void
     {
-        $mc = new Memcached();
+        $mc = new Memcached;
         $mc->addServer('memcached', 11211);
 
         self::$cache = new Cache(new MemcachedAdapter($mc));
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         self::$cache->save('test:file33', 'file33');
         $this->assertEquals(1, self::$cache->getSize());
     }
 
-    public function testCacheReconnect(): void
+    public function test_cache_reconnect(): void
     {
-        $mc = new Memcached();
+        $mc = new Memcached;
         $mc->addServer('memcached', 11211);
         self::$cache = new Cache((new MemcachedAdapter($mc))->setMaxRetries(3));
         self::$cache->save('test:reconnect', 'reconnect');

--- a/tests/Cache/MemoryTest.php
+++ b/tests/Cache/MemoryTest.php
@@ -9,10 +9,10 @@ class MemoryTest extends Base
 {
     public static function setUpBeforeClass(): void
     {
-        self::$cache = new Cache(new Memory());
+        self::$cache = new Cache(new Memory);
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         self::$cache->save('test:file33', 'file33');
         self::$cache->save('test:file34', 'file34');

--- a/tests/Cache/NoneTest.php
+++ b/tests/Cache/NoneTest.php
@@ -9,15 +9,15 @@ class NoneTest extends Base
 {
     public static function setUpBeforeClass(): void
     {
-        self::$cache = new Cache(new None());
+        self::$cache = new Cache(new None);
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         $this->assertEquals(0, self::$cache->getSize());
     }
 
-    public function testEmptyCacheKey(): void
+    public function test_empty_cache_key(): void
     {
         self::$cache->purge($this->key);
 
@@ -26,7 +26,7 @@ class NoneTest extends Base
         $this->assertEquals(false, $data);
     }
 
-    public function testCacheSave(): void
+    public function test_cache_save(): void
     {
         $result = self::$cache->save($this->key, $this->data);
 
@@ -34,9 +34,9 @@ class NoneTest extends Base
     }
 
     /**
-     * @depends testCacheSave
+     * @depends test_cache_save
      */
-    public function testCacheLoad(): void
+    public function test_cache_load(): void
     {
         $data = self::$cache->load($this->key, 60 * 60 * 24 * 30 * 3 /* 3 months */);
 
@@ -44,23 +44,23 @@ class NoneTest extends Base
     }
 
     /**
-     * @depends testCacheLoad
+     * @depends test_cache_load
      */
-    public function testNotEmptyCacheKey(): void
+    public function test_not_empty_cache_key(): void
     {
         $data = self::$cache->load($this->key, 60 * 60 * 24 * 30 * 3 /* 3 months */);
 
         $this->assertEquals(false, $data);
     }
 
-    public function testCachePurge(): void
+    public function test_cache_purge(): void
     {
         $result = self::$cache->purge($this->key);
 
         $this->assertEquals(true, $result);
     }
 
-    public function testCaseInsensitivity(): void
+    public function test_case_insensitivity(): void
     {
         // None adapter does not expect case sensitivity/insensitivy
         $this->assertEquals(true, true);

--- a/tests/Cache/PoolTest.php
+++ b/tests/Cache/PoolTest.php
@@ -17,14 +17,14 @@ class PoolTest extends Base
             mkdir($path, 0777, true);
         }
 
-        $pool = new UtopiaPool(new Stack(), 'test', 10, function () use ($path) {
+        $pool = new UtopiaPool(new Stack, 'test', 10, function () use ($path) {
             return new Filesystem($path);
         });
 
         self::$cache = new Cache(new Pool($pool));
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         self::$cache->save('test', 'test');
         $this->assertEquals(4, self::$cache->getSize());

--- a/tests/Cache/RedisClusterTest.php
+++ b/tests/Cache/RedisClusterTest.php
@@ -2,7 +2,7 @@
 
 namespace Utopia\Tests;
 
-use RedisCluster as RedisCluster;
+use RedisCluster;
 use Utopia\Cache\Adapter\RedisCluster as RedisAdapter;
 use Utopia\Cache\Cache;
 
@@ -24,7 +24,7 @@ class RedisClusterTest extends Base
         self::$cache = new Cache(new RedisAdapter(self::$redis, SEEDS));
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         for ($i = 0; $i < 20; $i++) {
             self::$cache->save("test:file$i", "file$i", "test:file$i");
@@ -34,9 +34,9 @@ class RedisClusterTest extends Base
     }
 
     /**
-     * @depends testGetSize
+     * @depends test_get_size
      */
-    public function testCacheReconnect(): void
+    public function test_cache_reconnect(): void
     {
         self::$redis = new RedisCluster(null, SEEDS, TIMEOUT, TIMEOUT);
         self::$cache = new Cache((new RedisAdapter(self::$redis, SEEDS))->setMaxRetries(3));

--- a/tests/Cache/RedisTest.php
+++ b/tests/Cache/RedisTest.php
@@ -2,7 +2,7 @@
 
 namespace Utopia\Tests;
 
-use Redis as Redis;
+use Redis;
 use Utopia\Cache\Adapter\Redis as RedisAdapter;
 use Utopia\Cache\Cache;
 
@@ -10,12 +10,12 @@ class RedisTest extends Base
 {
     public static function setUpBeforeClass(): void
     {
-        $redis = new Redis();
+        $redis = new Redis;
         $redis->connect('redis', 6379);
         self::$cache = new Cache(new RedisAdapter($redis));
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         self::$cache->save('test:file33', 'file33', 'test:file33');
         self::$cache->save('test:file34', 'file34', 'test:file34');
@@ -24,11 +24,11 @@ class RedisTest extends Base
     }
 
     /**
-     * @depends testGetSize
+     * @depends test_get_size
      */
-    public function testCacheReconnect(): void
+    public function test_cache_reconnect(): void
     {
-        $redis = new Redis();
+        $redis = new Redis;
         $redis->connect('redis', 6379);
         self::$cache = new Cache((new RedisAdapter($redis))->setMaxRetries(3));
 
@@ -56,11 +56,11 @@ class RedisTest extends Base
     }
 
     /**
-     * @depends testCacheReconnect
+     * @depends test_cache_reconnect
      */
-    public function testCacheReconnectPersistent(): void
+    public function test_cache_reconnect_persistent(): void
     {
-        $redis = new Redis();
+        $redis = new Redis;
         $redis->pconnect('redis', 6379);
         self::$cache = new Cache((new RedisAdapter($redis))->setMaxRetries(3));
 

--- a/tests/Cache/ShardingTest.php
+++ b/tests/Cache/ShardingTest.php
@@ -2,7 +2,7 @@
 
 namespace Utopia\Tests;
 
-use Redis as Redis;
+use Redis;
 use Throwable;
 use Utopia\Cache\Adapter\Redis as RedisAdapter;
 use Utopia\Cache\Adapter\Sharding;
@@ -12,13 +12,13 @@ class ShardingTest extends Base
 {
     public static function setUpBeforeClass(): void
     {
-        $shardA = new Redis();
+        $shardA = new Redis;
         $shardA->connect('shardA', 6379);
 
-        $shardB = new Redis();
+        $shardB = new Redis;
         $shardB->connect('shardB', 6379);
 
-        $shardC = new Redis();
+        $shardC = new Redis;
         $shardC->connect('shardC', 6379);
 
         self::$cache = new Cache(new Sharding([
@@ -28,14 +28,14 @@ class ShardingTest extends Base
         ]));
     }
 
-    public function testGetSize(): void
+    public function test_get_size(): void
     {
         self::$cache->save('test:file33', 'file33', 'test:file33');
         self::$cache->save('test:file34', 'file34', 'test:file33');
         $this->assertEquals(2, self::$cache->getSize());
     }
 
-    public function testEmptyAdapters(): void
+    public function test_empty_adapters(): void
     {
         $this->expectException(Throwable::class);
 


### PR DESCRIPTION
## Summary
- Add getter methods to all cache adapters so the underlying client/resource can be retrieved after construction
- `getClient()` on Redis, RedisCluster, Memcached, and Hazelcast adapters
- `getPath()` on Filesystem, `getPool()` on Pool, `getAdapters()` on Sharding

## Test plan
- [ ] Verify existing tests still pass
- [ ] Confirm each getter returns the same instance passed to the constructor