### PR TITLE
Add filesystem streaming loads

### DIFF
--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -13,13 +13,20 @@ class Filesystem implements Adapter
     protected $path = '';
 
     /**
+     * @var bool
+     */
+    protected bool $streaming = false;
+
+    /**
      * Filesystem constructor.
      *
      * @param  string  $path
+     * @param  bool  $streaming
      */
-    public function __construct(string $path)
+    public function __construct(string $path, bool $streaming = false)
     {
         $this->path = $path;
+        $this->streaming = $streaming;
     }
 
     /**
@@ -51,6 +58,10 @@ class Filesystem implements Adapter
         $file = $this->getPath($key);
 
         if (\file_exists($file) && (\filemtime($file) + $ttl > \time())) { // Cache is valid
+            if ($this->streaming) {
+                return \fopen($file, 'rb');
+            }
+
             return \file_get_contents($file);
         }
 

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -22,4 +22,34 @@ class FilesystemTest extends Base
         self::$cache->save('test', 'test');
         $this->assertEquals(4, self::$cache->getSize());
     }
+
+    public function testStreamingLoad(): void
+    {
+        $path = __DIR__.'/tests/stream-data';
+        if (! file_exists($path)) {
+            mkdir($path, 0777, true);
+        }
+
+        $cache = new Cache(new Filesystem($path, true));
+        $cache->save('stream-test', 'stream data');
+
+        $stream = $cache->load('stream-test', 60);
+
+        $this->assertTrue(is_resource($stream));
+        $this->assertEquals('stream data', stream_get_contents($stream));
+
+        fclose($stream);
+    }
+
+    public function testStreamingLoadMissingKey(): void
+    {
+        $path = __DIR__.'/tests/stream-missing-data';
+        if (! file_exists($path)) {
+            mkdir($path, 0777, true);
+        }
+
+        $cache = new Cache(new Filesystem($path, true));
+
+        $this->assertEquals(false, $cache->load('missing-stream-test', 60));
+    }
 }

--- a/tests/Cache/FilesystemTest.php
+++ b/tests/Cache/FilesystemTest.php
@@ -26,30 +26,63 @@ class FilesystemTest extends Base
     public function testStreamingLoad(): void
     {
         $path = __DIR__.'/tests/stream-data';
-        if (! file_exists($path)) {
-            mkdir($path, 0777, true);
+
+        try {
+            if (! file_exists($path)) {
+                mkdir($path, 0777, true);
+            }
+
+            $cache = new Cache(new Filesystem($path, true));
+            $cache->save('stream-test', 'stream data');
+
+            $stream = $cache->load('stream-test', 60);
+
+            $this->assertTrue(is_resource($stream));
+            $this->assertEquals('stream data', stream_get_contents($stream));
+
+            fclose($stream);
+        } finally {
+            $this->deletePath($path);
         }
-
-        $cache = new Cache(new Filesystem($path, true));
-        $cache->save('stream-test', 'stream data');
-
-        $stream = $cache->load('stream-test', 60);
-
-        $this->assertTrue(is_resource($stream));
-        $this->assertEquals('stream data', stream_get_contents($stream));
-
-        fclose($stream);
     }
 
     public function testStreamingLoadMissingKey(): void
     {
         $path = __DIR__.'/tests/stream-missing-data';
+
+        try {
+            if (! file_exists($path)) {
+                mkdir($path, 0777, true);
+            }
+
+            $cache = new Cache(new Filesystem($path, true));
+
+            $this->assertEquals(false, $cache->load('missing-stream-test', 60));
+        } finally {
+            $this->deletePath($path);
+        }
+    }
+
+    private function deletePath(string $path): void
+    {
         if (! file_exists($path)) {
-            mkdir($path, 0777, true);
+            return;
         }
 
-        $cache = new Cache(new Filesystem($path, true));
+        if (is_file($path)) {
+            unlink($path);
 
-        $this->assertEquals(false, $cache->load('missing-stream-test', 60));
+            return;
+        }
+
+        $files = glob($path.'/*');
+
+        if ($files !== false) {
+            foreach ($files as $file) {
+                $this->deletePath($file);
+            }
+        }
+
+        rmdir($path);
     }
 }


### PR DESCRIPTION
## Summary
- Add an optional constructor flag to the filesystem adapter for stream-based cache loads.
- Return readable file handles for valid cache hits when streaming is enabled.
- Cover streaming cache hits and missing keys with filesystem tests.

## Tests
- vendor/bin/phpunit --configuration phpunit.xml tests/Cache/FilesystemTest.php --filter 'testStreamingLoad|testStreamingLoadMissingKey'
- composer lint
- composer check

## Note
- Full FilesystemTest still has the existing macOS case-insensitive filesystem failure in Base::testCaseInsensitivity.