### PR TITLE
Add cache touch support

### DIFF
--- a/src/Cache/Adapter.php
+++ b/src/Cache/Adapter.php
@@ -26,6 +26,13 @@ interface Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool;
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array;

--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -99,6 +99,18 @@ class Filesystem implements Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        $file = $this->getPath($key);
+
+        return file_exists($file) && touch($file);
+    }
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array

--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -106,7 +106,13 @@ class Filesystem implements Adapter
     {
         $file = $this->getPath($key);
 
-        return file_exists($file) && touch($file);
+        if (! file_exists($file) || ! touch($file)) {
+            return false;
+        }
+
+        clearstatcache(true, $file);
+
+        return true;
     }
 
     /**

--- a/src/Cache/Adapter/Hazelcast.php
+++ b/src/Cache/Adapter/Hazelcast.php
@@ -89,6 +89,25 @@ class Hazelcast implements Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        $data = $this->load($key, PHP_INT_MAX, $hash);
+        if ($data === false) {
+            return false;
+        }
+
+        if (! is_string($data) && ! is_array($data)) {
+            return false;
+        }
+
+        return $this->save($key, $data, $hash) !== false;
+    }
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array

--- a/src/Cache/Adapter/Hazelcast.php
+++ b/src/Cache/Adapter/Hazelcast.php
@@ -94,16 +94,18 @@ class Hazelcast implements Adapter
      */
     public function touch(string $key, string $hash = ''): bool
     {
-        $data = $this->load($key, PHP_INT_MAX, $hash);
-        if ($data === false) {
+        $cache = $this->execute(fn () => $this->memcached->get($key));
+        if (is_string($cache)) {
+            $cache = json_decode($cache, true);
+        }
+
+        if (! is_array($cache)) {
             return false;
         }
 
-        if (! is_string($data) && ! is_array($data)) {
-            return false;
-        }
+        $cache['time'] = time();
 
-        return $this->save($key, $data, $hash) !== false;
+        return (bool) $this->execute(fn () => $this->memcached->set($key, json_encode($cache)));
     }
 
     /**

--- a/src/Cache/Adapter/Memcached.php
+++ b/src/Cache/Adapter/Memcached.php
@@ -91,6 +91,25 @@ class Memcached implements Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        $data = $this->load($key, PHP_INT_MAX, $hash);
+        if ($data === false) {
+            return false;
+        }
+
+        if (! is_string($data) && ! is_array($data)) {
+            return false;
+        }
+
+        return $this->save($key, $data, $hash) !== false;
+    }
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array

--- a/src/Cache/Adapter/Memcached.php
+++ b/src/Cache/Adapter/Memcached.php
@@ -96,16 +96,15 @@ class Memcached implements Adapter
      */
     public function touch(string $key, string $hash = ''): bool
     {
-        $data = $this->load($key, PHP_INT_MAX, $hash);
-        if ($data === false) {
+        /** @var array{time: int, data: string|array<int|string, mixed>}|false */
+        $cache = $this->execute(fn () => $this->memcached->get($key));
+        if ($cache === false) {
             return false;
         }
 
-        if (! is_string($data) && ! is_array($data)) {
-            return false;
-        }
+        $cache['time'] = time();
 
-        return $this->save($key, $data, $hash) !== false;
+        return (bool) $this->execute(fn () => $this->memcached->set($key, $cache));
     }
 
     /**

--- a/src/Cache/Adapter/Memory.php
+++ b/src/Cache/Adapter/Memory.php
@@ -78,6 +78,25 @@ class Memory implements Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        $data = $this->load($key, PHP_INT_MAX, $hash);
+        if ($data === false) {
+            return false;
+        }
+
+        if (! is_string($data) && ! is_array($data)) {
+            return false;
+        }
+
+        return $this->save($key, $data, $hash) !== false;
+    }
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array

--- a/src/Cache/Adapter/Memory.php
+++ b/src/Cache/Adapter/Memory.php
@@ -83,16 +83,16 @@ class Memory implements Adapter
      */
     public function touch(string $key, string $hash = ''): bool
     {
-        $data = $this->load($key, PHP_INT_MAX, $hash);
-        if ($data === false) {
+        if (empty($key) || ! isset($this->store[$key])) {
             return false;
         }
 
-        if (! is_string($data) && ! is_array($data)) {
-            return false;
-        }
+        /** @var array{time: int, data: string|array<int|string, mixed>} $saved */
+        $saved = $this->store[$key];
+        $saved['time'] = time();
+        $this->store[$key] = $saved;
 
-        return $this->save($key, $data, $hash) !== false;
+        return true;
     }
 
     /**

--- a/src/Cache/Adapter/None.php
+++ b/src/Cache/Adapter/None.php
@@ -55,6 +55,16 @@ class None implements Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array

--- a/src/Cache/Adapter/Pool.php
+++ b/src/Cache/Adapter/Pool.php
@@ -59,6 +59,16 @@ class Pool implements Adapter
         return $result;
     }
 
+    public function touch(string $key, string $hash = ''): bool
+    {
+        /**
+         * @var bool $result
+         */
+        $result = $this->delegate(__FUNCTION__, \func_get_args());
+
+        return $result;
+    }
+
     public function list(string $key): array
     {
         /**

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -154,6 +154,25 @@ class Redis implements Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        $data = $this->load($key, PHP_INT_MAX, $hash);
+        if ($data === false) {
+            return false;
+        }
+
+        if (! is_string($data) && ! is_array($data)) {
+            return false;
+        }
+
+        return $this->save($key, $data, $hash) !== false;
+    }
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -159,16 +159,26 @@ class Redis implements Adapter
      */
     public function touch(string $key, string $hash = ''): bool
     {
-        $data = $this->load($key, PHP_INT_MAX, $hash);
-        if ($data === false) {
+        if (empty($hash)) {
+            $hash = $key;
+        }
+
+        $redis_string = $this->execute(fn () => $this->redis->hGet($key, $hash));
+
+        if ($redis_string === false || $redis_string === null || ! is_string($redis_string)) {
             return false;
         }
 
-        if (! is_string($data) && ! is_array($data)) {
+        try {
+            /** @var array{time: int, data: mixed} $cache */
+            $cache = json_decode($redis_string, true, flags: JSON_THROW_ON_ERROR);
+            $cache['time'] = time();
+            $value = json_encode($cache, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable $th) {
             return false;
         }
 
-        return $this->save($key, $data, $hash) !== false;
+        return $this->execute(fn () => $this->redis->hSet($key, $hash, $value)) !== false;
     }
 
     /**

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -103,7 +103,7 @@ class RedisCluster implements Adapter
         /** @var string|false */
         $redis_string = $this->execute(fn () => $this->redis->hGet($key, $hash));
 
-        if ($redis_string === false) {
+        if ($redis_string === false || ! is_string($redis_string)) {
             return false;
         }
 
@@ -149,6 +149,25 @@ class RedisCluster implements Adapter
         } catch (Throwable $th) {
             return false;
         }
+    }
+
+    /**
+     * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        $data = $this->load($key, PHP_INT_MAX, $hash);
+        if ($data === false) {
+            return false;
+        }
+
+        if (! is_string($data) && ! is_array($data)) {
+            return false;
+        }
+
+        return $this->save($key, $data, $hash) !== false;
     }
 
     /**

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -158,16 +158,27 @@ class RedisCluster implements Adapter
      */
     public function touch(string $key, string $hash = ''): bool
     {
-        $data = $this->load($key, PHP_INT_MAX, $hash);
-        if ($data === false) {
+        if (empty($hash)) {
+            $hash = $key;
+        }
+
+        /** @var string|false */
+        $redis_string = $this->execute(fn () => $this->redis->hGet($key, $hash));
+
+        if ($redis_string === false || ! is_string($redis_string)) {
             return false;
         }
 
-        if (! is_string($data) && ! is_array($data)) {
+        try {
+            /** @var array{time: int, data: mixed} $cache */
+            $cache = json_decode($redis_string, true, flags: JSON_THROW_ON_ERROR);
+            $cache['time'] = time();
+            $value = json_encode($cache, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable $th) {
             return false;
         }
 
-        return $this->save($key, $data, $hash) !== false;
+        return $this->execute(fn () => $this->redis->hSet($key, $hash, $value)) !== false;
     }
 
     /**

--- a/src/Cache/Adapter/Sharding.php
+++ b/src/Cache/Adapter/Sharding.php
@@ -94,6 +94,16 @@ class Sharding implements Adapter
 
     /**
      * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        return $this->getAdapter($key)->touch($key, $hash);
+    }
+
+    /**
+     * @param  string  $key
      * @return string[]
      */
     public function list(string $key): array

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -107,6 +107,29 @@ class Cache
     }
 
     /**
+     * Refresh a cache entry timestamp without replacing its data.
+     *
+     * @param  string  $key
+     * @param  string  $hash optional
+     * @return bool
+     */
+    public function touch(string $key, string $hash = ''): bool
+    {
+        $key = $this->caseSensitive ? $key : strtolower($key);
+        $hash = $this->caseSensitive ? $hash : strtolower($hash);
+
+        $start = microtime(true);
+        $result = $this->adapter->touch($key, $hash);
+        $duration = microtime(true) - $start;
+        $this->operationDuration?->record($duration, [
+            'operation' => 'touch',
+            'adapter' => $this->adapter->getName($key),
+        ]);
+
+        return $result;
+    }
+
+    /**
      * Returns a list of keys.
      *
      * @param  string  $key

--- a/tests/Cache/Base.php
+++ b/tests/Cache/Base.php
@@ -62,8 +62,11 @@ abstract class Base extends TestCase
         $result = self::$cache->save('touch-key', 'touch data', 'touch-key');
         $this->assertEquals('touch data', $result);
 
+        sleep(2);
+
+        $this->assertEquals(false, self::$cache->load('touch-key', 1, 'touch-key'));
         $this->assertEquals(true, self::$cache->touch('touch-key', 'touch-key'));
-        $this->assertEquals('touch data', self::$cache->load('touch-key', 60, 'touch-key'));
+        $this->assertEquals('touch data', self::$cache->load('touch-key', 1, 'touch-key'));
         $this->assertEquals(false, self::$cache->touch('missing-touch-key', 'missing-touch-key'));
 
         self::$cache->purge('touch-key');

--- a/tests/Cache/Base.php
+++ b/tests/Cache/Base.php
@@ -62,11 +62,11 @@ abstract class Base extends TestCase
         $result = self::$cache->save('touch-key', 'touch data', 'touch-key');
         $this->assertEquals('touch data', $result);
 
-        sleep(2);
+        sleep(3);
 
-        $this->assertEquals(false, self::$cache->load('touch-key', 1, 'touch-key'));
+        $this->assertEquals(false, self::$cache->load('touch-key', 2, 'touch-key'));
         $this->assertEquals(true, self::$cache->touch('touch-key', 'touch-key'));
-        $this->assertEquals('touch data', self::$cache->load('touch-key', 1, 'touch-key'));
+        $this->assertEquals('touch data', self::$cache->load('touch-key', 2, 'touch-key'));
         $this->assertEquals(false, self::$cache->touch('missing-touch-key', 'missing-touch-key'));
 
         self::$cache->purge('touch-key');

--- a/tests/Cache/Base.php
+++ b/tests/Cache/Base.php
@@ -57,6 +57,18 @@ abstract class Base extends TestCase
         $this->assertEquals(false, $data);
     }
 
+    public function testCacheTouch(): void
+    {
+        $result = self::$cache->save('touch-key', 'touch data', 'touch-key');
+        $this->assertEquals('touch data', $result);
+
+        $this->assertEquals(true, self::$cache->touch('touch-key', 'touch-key'));
+        $this->assertEquals('touch data', self::$cache->load('touch-key', 60, 'touch-key'));
+        $this->assertEquals(false, self::$cache->touch('missing-touch-key', 'missing-touch-key'));
+
+        self::$cache->purge('touch-key');
+    }
+
     public function testCaseInsensitivity(): void
     {
         // Ensure case in-sensitivity first (configured in adapter's setUp)

--- a/tests/Cache/MemoryTest.php
+++ b/tests/Cache/MemoryTest.php
@@ -20,20 +20,4 @@ class MemoryTest extends Base
         self::$cache->save('test:file36', 'file36');
         $this->assertEquals(4, self::$cache->getSize());
     }
-
-    public function testTouchExpiredEntry(): void
-    {
-        $adapter = new Memory();
-        $cache = new Cache($adapter);
-
-        $cache->save('expired-touch-key', 'expired data');
-        /** @var array{time: int, data: string} $stored */
-        $stored = $adapter->store['expired-touch-key'];
-        $stored['time'] = time() - 10;
-        $adapter->store['expired-touch-key'] = $stored;
-
-        $this->assertEquals(false, $cache->load('expired-touch-key', 1));
-        $this->assertEquals(true, $cache->touch('expired-touch-key'));
-        $this->assertEquals('expired data', $cache->load('expired-touch-key', 1));
-    }
 }

--- a/tests/Cache/MemoryTest.php
+++ b/tests/Cache/MemoryTest.php
@@ -20,4 +20,20 @@ class MemoryTest extends Base
         self::$cache->save('test:file36', 'file36');
         $this->assertEquals(4, self::$cache->getSize());
     }
+
+    public function testTouchExpiredEntry(): void
+    {
+        $adapter = new Memory();
+        $cache = new Cache($adapter);
+
+        $cache->save('expired-touch-key', 'expired data');
+        /** @var array{time: int, data: string} $stored */
+        $stored = $adapter->store['expired-touch-key'];
+        $stored['time'] = time() - 10;
+        $adapter->store['expired-touch-key'] = $stored;
+
+        $this->assertEquals(false, $cache->load('expired-touch-key', 1));
+        $this->assertEquals(true, $cache->touch('expired-touch-key'));
+        $this->assertEquals('expired data', $cache->load('expired-touch-key', 1));
+    }
 }

--- a/tests/Cache/NoneTest.php
+++ b/tests/Cache/NoneTest.php
@@ -60,6 +60,11 @@ class NoneTest extends Base
         $this->assertEquals(true, $result);
     }
 
+    public function testCacheTouch(): void
+    {
+        $this->assertEquals(false, self::$cache->touch($this->key));
+    }
+
     public function testCaseInsensitivity(): void
     {
         // None adapter does not expect case sensitivity/insensitivy


### PR DESCRIPTION
## Summary
- Add a public `touch()` cache API for refreshing an existing entry timestamp without changing its data.
- Implement `touch()` across all adapters, delegating through existing load/save paths where appropriate.
- Add shared adapter coverage for successful and missing-entry touch behavior.

## Testing
- `composer format`
- `composer check`
- `composer lint`
- `./vendor/bin/phpunit tests/Cache/MemoryTest.php tests/Cache/NoneTest.php tests/Cache/FilesystemTest.php --filter 'testCacheTouch|testCacheSave|testCachePurge'`

## Notes
- Full PHPUnit was not green locally because Redis hostnames are unavailable, the Memcached extension is missing, and the filesystem case-sensitivity assertion fails on this macOS case-insensitive filesystem.