### PR TITLE
refactor: extract Retryable into a Feature interface

### DIFF
--- a/src/Cache/Adapter.php
+++ b/src/Cache/Adapter.php
@@ -4,10 +4,6 @@ namespace Utopia\Cache;
 
 interface Adapter
 {
-    const MIN_RETRIES = 0;
-
-    const MAX_RETRIES = 10;
-
     /**
      * @param  string  $key
      * @param  int  $ttl time in seconds
@@ -64,26 +60,4 @@ interface Adapter
      * @return string
      */
     public function getName(?string $key = null): string;
-
-    /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
-     */
-    public function setMaxRetries(int $maxRetries): self;
-
-    /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
-     */
-    public function setRetryDelay(int $retryDelay): self;
-
-    /**
-     * @return int
-     */
-    public function getMaxRetries(): int;
-
-    /**
-     * @return int
-     */
-    public function getRetryDelay(): int;
 }

--- a/src/Cache/Adapter/CircuitBreaker.php
+++ b/src/Cache/Adapter/CircuitBreaker.php
@@ -111,27 +111,4 @@ class CircuitBreaker implements Adapter, Feature\Telemetry
         }
     }
 
-    public function setMaxRetries(int $maxRetries): self
-    {
-        $this->adapter->setMaxRetries($maxRetries);
-
-        return $this;
-    }
-
-    public function setRetryDelay(int $retryDelay): self
-    {
-        $this->adapter->setRetryDelay($retryDelay);
-
-        return $this;
-    }
-
-    public function getMaxRetries(): int
-    {
-        return $this->adapter->getMaxRetries();
-    }
-
-    public function getRetryDelay(): int
-    {
-        return $this->adapter->getRetryDelay();
-    }
 }

--- a/src/Cache/Adapter/CircuitBreaker.php
+++ b/src/Cache/Adapter/CircuitBreaker.php
@@ -110,5 +110,4 @@ class CircuitBreaker implements Adapter, Feature\Telemetry
             $this->adapter->setTelemetry($telemetry);
         }
     }
-
 }

--- a/src/Cache/Adapter/Filesystem.php
+++ b/src/Cache/Adapter/Filesystem.php
@@ -30,24 +30,6 @@ class Filesystem implements Adapter
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
-     */
-    public function setMaxRetries(int $maxRetries): self
-    {
-        return $this;
-    }
-
-    /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
-     */
-    public function setRetryDelay(int $retryDelay): self
-    {
-        return $this;
-    }
-
-    /**
      * @param  string  $key
      * @param  int  $ttl time in seconds
      * @param  string  $hash optional
@@ -245,21 +227,5 @@ class Filesystem implements Adapter
     public function getName(?string $key = null): string
     {
         return 'filesystem';
-    }
-
-    /**
-     * @return int
-     */
-    public function getMaxRetries(): int
-    {
-        return 0;
-    }
-
-    /**
-     * @return int
-     */
-    public function getRetryDelay(): int
-    {
-        return 1000;
     }
 }

--- a/src/Cache/Adapter/Hazelcast.php
+++ b/src/Cache/Adapter/Hazelcast.php
@@ -4,8 +4,9 @@ namespace Utopia\Cache\Adapter;
 
 use Memcached as Client;
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Feature\Retryable;
 
-class Hazelcast implements Adapter
+class Hazelcast implements Adapter, Retryable
 {
     /**
      * @var Client
@@ -27,7 +28,7 @@ class Hazelcast implements Adapter
      */
     public function setMaxRetries(int $maxRetries): self
     {
-        $this->maxRetries = max(self::MIN_RETRIES, min($maxRetries, self::MAX_RETRIES));
+        $this->maxRetries = max(Retryable::MIN_RETRIES, min($maxRetries, Retryable::MAX_RETRIES));
 
         return $this;
     }

--- a/src/Cache/Adapter/Memcached.php
+++ b/src/Cache/Adapter/Memcached.php
@@ -4,8 +4,9 @@ namespace Utopia\Cache\Adapter;
 
 use Memcached as Client;
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Feature\Retryable;
 
-class Memcached implements Adapter
+class Memcached implements Adapter, Retryable
 {
     /**
      * @var Client
@@ -32,7 +33,7 @@ class Memcached implements Adapter
      */
     public function setMaxRetries(int $maxRetries): self
     {
-        $this->maxRetries = max(self::MIN_RETRIES, min($maxRetries, self::MAX_RETRIES));
+        $this->maxRetries = max(Retryable::MIN_RETRIES, min($maxRetries, Retryable::MAX_RETRIES));
 
         return $this;
     }

--- a/src/Cache/Adapter/Memory.php
+++ b/src/Cache/Adapter/Memory.php
@@ -19,24 +19,6 @@ class Memory implements Adapter
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
-     */
-    public function setMaxRetries(int $maxRetries): self
-    {
-        return $this;
-    }
-
-    /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
-     */
-    public function setRetryDelay(int $retryDelay): self
-    {
-        return $this;
-    }
-
-    /**
      * @param  string  $key
      * @param  int  $ttl
      * @param  string  $hash optional
@@ -155,21 +137,5 @@ class Memory implements Adapter
     public function getName(?string $key = null): string
     {
         return 'memory';
-    }
-
-    /**
-     * @return int
-     */
-    public function getMaxRetries(): int
-    {
-        return 0;
-    }
-
-    /**
-     * @return int
-     */
-    public function getRetryDelay(): int
-    {
-        return 0;
     }
 }

--- a/src/Cache/Adapter/None.php
+++ b/src/Cache/Adapter/None.php
@@ -14,24 +14,6 @@ class None implements Adapter
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
-     */
-    public function setMaxRetries(int $maxRetries): self
-    {
-        return $this;
-    }
-
-    /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
-     */
-    public function setRetryDelay(int $retryDelay): self
-    {
-        return $this;
-    }
-
-    /**
      * @param  string  $key
      * @param  int  $ttl
      * @param  string  $hash optional
@@ -113,21 +95,5 @@ class None implements Adapter
     public function getName(?string $key = null): string
     {
         return 'none';
-    }
-
-    /**
-     * @return int
-     */
-    public function getMaxRetries(): int
-    {
-        return 0;
-    }
-
-    /**
-     * @return int
-     */
-    public function getRetryDelay(): int
-    {
-        return 0;
     }
 }

--- a/src/Cache/Adapter/Pool.php
+++ b/src/Cache/Adapter/Pool.php
@@ -128,5 +128,4 @@ class Pool implements Adapter
 
         return $result;
     }
-
 }

--- a/src/Cache/Adapter/Pool.php
+++ b/src/Cache/Adapter/Pool.php
@@ -129,37 +129,4 @@ class Pool implements Adapter
         return $result;
     }
 
-    public function setMaxRetries(int $maxRetries): self
-    {
-        $this->delegate(__FUNCTION__, \func_get_args());
-
-        return $this;
-    }
-
-    public function setRetryDelay(int $retryDelay): self
-    {
-        $this->delegate(__FUNCTION__, \func_get_args());
-
-        return $this;
-    }
-
-    public function getMaxRetries(): int
-    {
-        /**
-         * @var int $result
-         */
-        $result = $this->delegate(__FUNCTION__, \func_get_args());
-
-        return $result;
-    }
-
-    public function getRetryDelay(): int
-    {
-        /**
-         * @var int $result
-         */
-        $result = $this->delegate(__FUNCTION__, \func_get_args());
-
-        return $result;
-    }
 }

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -7,8 +7,9 @@ use Redis as Client;
 use Throwable;
 use Utopia\Cache\Adapter;
 use Utopia\Cache\Adapter\Redis\Envelope;
+use Utopia\Cache\Feature\Retryable;
 
-class Redis implements Adapter
+class Redis implements Adapter, Retryable
 {
     /**
      * @var Client
@@ -72,7 +73,7 @@ class Redis implements Adapter
      */
     public function setMaxRetries(int $maxRetries): self
     {
-        $this->maxRetries = max(self::MIN_RETRIES, min($maxRetries, self::MAX_RETRIES));
+        $this->maxRetries = max(Retryable::MIN_RETRIES, min($maxRetries, Retryable::MAX_RETRIES));
 
         return $this;
     }

--- a/src/Cache/Adapter/Redis/Multiplexing.php
+++ b/src/Cache/Adapter/Redis/Multiplexing.php
@@ -25,10 +25,6 @@ use Utopia\Telemetry\Gauge;
  */
 class Multiplexing implements Adapter, TelemetryFeature
 {
-    private int $maxRetries = 0;
-
-    private int $retryDelay = 1000; // milliseconds
-
     private ?ConnectionContext $connection = null;
 
     /**
@@ -96,30 +92,6 @@ class Multiplexing implements Adapter, TelemetryFeature
         $this->shutdown();
     }
 
-    public function setMaxRetries(int $maxRetries): self
-    {
-        $this->maxRetries = max(self::MIN_RETRIES, min($maxRetries, self::MAX_RETRIES));
-
-        return $this;
-    }
-
-    public function setRetryDelay(int $retryDelay): self
-    {
-        $this->retryDelay = $retryDelay;
-
-        return $this;
-    }
-
-    public function getMaxRetries(): int
-    {
-        return $this->maxRetries;
-    }
-
-    public function getRetryDelay(): int
-    {
-        return $this->retryDelay;
-    }
-
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
         if (empty($hash)) {
@@ -145,14 +117,10 @@ class Multiplexing implements Adapter, TelemetryFeature
             $hash = $key;
         }
 
-        try {
-            $value = Envelope::encode($data, time());
-            $this->command(['HSET', $key, $hash, $value]);
+        $value = Envelope::encode($data, time());
+        $this->command(['HSET', $key, $hash, $value]);
 
-            return $data;
-        } catch (Throwable $th) {
-            return false;
-        }
+        return $data;
     }
 
     public function touch(string $key, string $hash = ''): bool
@@ -225,36 +193,21 @@ class Multiplexing implements Adapter, TelemetryFeature
 
     /**
      * Send a Redis command and block the calling coroutine until the response arrives.
+     * On a connection error, transparently reconnects once and retries — multiplexed
+     * connections drop all in-flight callers when they fail, so the only sensible
+     * recovery is to rebuild the connection before failing the call.
      *
      * @param  array<int|string>  $args
      */
     private function command(array $args): mixed
     {
-        $attempts = 0;
-        $maxAttempts = 1 + $this->maxRetries;
+        try {
+            return $this->dispatch($args);
+        } catch (ConnectionException $th) {
+            $this->ensureConnected();
 
-        while (true) {
-            try {
-                return $this->dispatch($args);
-            } catch (ConnectionException $th) {
-                if (++$attempts >= $maxAttempts) {
-                    throw $th;
-                }
-
-                Coroutine::sleep($this->retryDelaySeconds());
-                $this->ensureConnected();
-            }
+            return $this->dispatch($args);
         }
-    }
-
-    private function retryDelaySeconds(): float
-    {
-        $baseDelay = max(0, $this->retryDelay) / 1000;
-        if ($baseDelay === 0.0) {
-            return 0.0;
-        }
-
-        return $baseDelay + mt_rand(0, 100) / 1000;
     }
 
     /**
@@ -294,6 +247,18 @@ class Multiplexing implements Adapter, TelemetryFeature
         return $this->awaitResponse($context, $response);
     }
 
+    private function ensureConnected(): void
+    {
+        $locked = $this->lockSend();
+        try {
+            if ($this->connection === null) {
+                $this->connect();
+            }
+        } finally {
+            $this->unlockSend($locked);
+        }
+    }
+
     /**
      * @param  Channel<mixed>  $response
      */
@@ -308,18 +273,6 @@ class Multiplexing implements Adapter, TelemetryFeature
         }
 
         return Client::unwrap($result);
-    }
-
-    private function ensureConnected(): void
-    {
-        $locked = $this->lockSend();
-        try {
-            if ($this->connection === null) {
-                $this->connect();
-            }
-        } finally {
-            $this->unlockSend($locked);
-        }
     }
 
     /**

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -6,8 +6,9 @@ use Exception;
 use RedisCluster as Client;
 use Throwable;
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Feature\Retryable;
 
-class RedisCluster implements Adapter
+class RedisCluster implements Adapter, Retryable
 {
     /**
      * @var Client
@@ -72,7 +73,7 @@ class RedisCluster implements Adapter
      */
     public function setMaxRetries(int $maxRetries): self
     {
-        $this->maxRetries = max(self::MIN_RETRIES, min($maxRetries, self::MAX_RETRIES));
+        $this->maxRetries = max(Retryable::MIN_RETRIES, min($maxRetries, Retryable::MAX_RETRIES));
 
         return $this;
     }

--- a/src/Cache/Adapter/Sharding.php
+++ b/src/Cache/Adapter/Sharding.php
@@ -45,32 +45,6 @@ class Sharding implements Adapter
     }
 
     /**
-     * @param  int  $maxRetries (0-10)
-     * @return self
-     */
-    public function setMaxRetries(int $maxRetries): self
-    {
-        foreach ($this->adapters as $adapter) {
-            $adapter->setMaxRetries($maxRetries);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param  int  $retryDelay time in milliseconds
-     * @return self
-     */
-    public function setRetryDelay(int $retryDelay): self
-    {
-        foreach ($this->adapters as $adapter) {
-            $adapter->setRetryDelay($retryDelay);
-        }
-
-        return $this;
-    }
-
-    /**
      * @param  string  $key
      * @param  int  $ttl time in seconds
      * @param  string  $hash optional
@@ -185,21 +159,5 @@ class Sharding implements Adapter
         $index = $hash % $this->count;
 
         return $this->adapters[$index];
-    }
-
-    /**
-     * @return int
-     */
-    public function getMaxRetries(): int
-    {
-        return 0;
-    }
-
-    /**
-     * @return int
-     */
-    public function getRetryDelay(): int
-    {
-        return 0;
     }
 }

--- a/src/Cache/Feature/Retryable.php
+++ b/src/Cache/Feature/Retryable.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Utopia\Cache\Feature;
+
+interface Retryable
+{
+    const MIN_RETRIES = 0;
+
+    const MAX_RETRIES = 10;
+
+    /**
+     * @param  int  $maxRetries (0-10)
+     * @return self
+     */
+    public function setMaxRetries(int $maxRetries): self;
+
+    /**
+     * @param  int  $retryDelay time in milliseconds
+     * @return self
+     */
+    public function setRetryDelay(int $retryDelay): self;
+
+    /**
+     * @return int
+     */
+    public function getMaxRetries(): int;
+
+    /**
+     * @return int
+     */
+    public function getRetryDelay(): int;
+}

--- a/tests/Cache/E2E/CircuitBreakerTest.php
+++ b/tests/Cache/E2E/CircuitBreakerTest.php
@@ -152,26 +152,6 @@ class FailingAdapter implements Adapter
     {
         return 'failing';
     }
-
-    public function setMaxRetries(int $maxRetries): self
-    {
-        return $this;
-    }
-
-    public function setRetryDelay(int $retryDelay): self
-    {
-        return $this;
-    }
-
-    public function getMaxRetries(): int
-    {
-        return 0;
-    }
-
-    public function getRetryDelay(): int
-    {
-        return 0;
-    }
 }
 
 class CountingFailingAdapter extends FailingAdapter


### PR DESCRIPTION
## Summary
- Move retry knobs off the base `Adapter` interface into a new `Cache\Feature\Retryable` interface, mirroring the existing `Feature\Telemetry` pattern. Only adapters that actually retry against a real connection (`Redis`, `RedisCluster`, `Memcached`, `Hazelcast`) implement it.
- Drop no-op / fan-out retry methods from `Filesystem`, `Memory`, `None`, `Pool`, `Sharding`, and `CircuitBreaker`.
- Strip configurable retries from `Redis\Multiplexing` (configurable retries don't fit a shared connection — a teardown drops all in-flight callers), but keep a single transparent reconnect-and-retry on `ConnectionException` so callers don't see spurious failures right after a connection drop.
- Fix `Redis\Multiplexing::save()` swallowing connection exceptions in its encode/dispatch try block.

## Test plan
- [ ] `composer test` (unit suite)
- [ ] E2E suites for Redis / RedisCluster / Memcached / Hazelcast still pass with `setMaxRetries(3)`
- [ ] Confirm Swoole multiplexing E2E still recovers from a Redis restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)