### PR TITLE
feat: hit/miss counter + fix multiplexing pending-depth gauge

### DIFF
--- a/src/Cache/Adapter/Redis/Multiplexing.php
+++ b/src/Cache/Adapter/Redis/Multiplexing.php
@@ -11,7 +11,7 @@ use Utopia\Cache\Adapter;
 use Utopia\Cache\Feature\Telemetry as TelemetryFeature;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
-use Utopia\Telemetry\Gauge;
+use Utopia\Telemetry\UpDownCounter;
 
 /**
  * Redis\Multiplexing adapter.
@@ -33,7 +33,7 @@ class Multiplexing implements Adapter, TelemetryFeature
      */
     private Lock $sendLock;
 
-    private ?Gauge $pendingDepth = null;
+    private ?UpDownCounter $pendingDepth = null;
 
     /**
      * @param  string  $host
@@ -70,14 +70,14 @@ class Multiplexing implements Adapter, TelemetryFeature
     }
 
     /**
-     * Wire a telemetry adapter for connection-level metrics. The current
-     * pending-queue depth is recorded after each enqueue — a steady-state
-     * non-zero value means callers are queueing faster than Redis is
-     * replying.
+     * Wire a telemetry adapter for connection-level metrics. The pending-queue
+     * depth is tracked as an up/down counter — incremented on enqueue and
+     * decremented on dequeue — so a steady-state non-zero value means callers
+     * are queueing faster than Redis is replying.
      */
     public function setTelemetry(Telemetry $telemetry): void
     {
-        $this->pendingDepth = $telemetry->createGauge(
+        $this->pendingDepth = $telemetry->createUpDownCounter(
             'cache.redis_multiplexing.pending.depth',
             description: 'Pending response channels awaiting RESP frames on the multiplexed connection.',
         );
@@ -228,7 +228,7 @@ class Multiplexing implements Adapter, TelemetryFeature
             $error = null;
 
             $context->pending->enqueue($response);
-            $this->pendingDepth?->record($context->pending->count());
+            $this->pendingDepth?->add(1);
             try {
                 $context->client->send(Client::encode($args));
             } catch (ConnectionException $sendError) {
@@ -340,6 +340,7 @@ class Multiplexing implements Adapter, TelemetryFeature
         while (! $context->pending->isEmpty()) {
             $ch = $context->pending->dequeue();
             if ($ch instanceof Channel) {
+                $this->pendingDepth?->add(-1);
                 $ch->push(new ConnectionError($error));
             }
         }
@@ -411,6 +412,7 @@ class Multiplexing implements Adapter, TelemetryFeature
                 // A complete frame implies a prior pending enqueue.
                 $waiting = $context->pending->isEmpty() ? null : $context->pending->dequeue();
                 if ($waiting instanceof Channel) {
+                    $this->pendingDepth?->add(-1);
                     $waiting->push($value);
                 } else {
                     // Should never happen given the send-lock invariant. Log

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -4,6 +4,7 @@ namespace Utopia\Cache;
 
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
+use Utopia\Telemetry\Counter;
 use Utopia\Telemetry\Histogram;
 
 class Cache
@@ -21,6 +22,11 @@ class Cache
     protected ?Histogram $operationDuration = null;
 
     /**
+     * @var Counter|null
+     */
+    protected ?Counter $loadResults = null;
+
+    /**
      * Set telemetry adapter and create histograms for cache operations.
      *
      * @param  Telemetry  $telemetry
@@ -32,6 +38,11 @@ class Cache
             's',
             null,
             ['ExplicitBucketBoundaries' => [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1]]
+        );
+        $this->loadResults = $telemetry->createCounter(
+            'cache.load.total',
+            null,
+            'Cache load operations broken down by hit/miss result.',
         );
 
         if ($this->adapter instanceof Feature\Telemetry) {
@@ -77,9 +88,14 @@ class Cache
         $start = microtime(true);
         $result = $this->adapter->load($key, $ttl, $hash);
         $duration = microtime(true) - $start;
+        $adapterName = $this->adapter->getName($key);
         $this->operationDuration?->record($duration, [
             'operation' => 'load',
-            'adapter' => $this->adapter->getName($key),
+            'adapter' => $adapterName,
+        ]);
+        $this->loadResults?->add(1, [
+            'adapter' => $adapterName,
+            'result' => $result ? 'hit' : 'miss',
         ]);
 
         return $result;

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -95,7 +95,7 @@ class Cache
         ]);
         $this->loadResults?->add(1, [
             'adapter' => $adapterName,
-            'result' => $result ? 'hit' : 'miss',
+            'result' => $result === false ? 'miss' : 'hit',
         ]);
 
         return $result;

--- a/tests/Cache/Unit/LoadResultsTelemetryTest.php
+++ b/tests/Cache/Unit/LoadResultsTelemetryTest.php
@@ -63,4 +63,48 @@ class LoadResultsTelemetryTest extends TestCase
         $results = \array_column($captured, 'result');
         $this->assertSame(['miss', 'hit'], $results);
     }
+
+    public function testNullReturnIsTreatedAsHit(): void
+    {
+        $captured = [];
+
+        $adapter = new class extends Memory {
+            public function load(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return null;
+            }
+        };
+
+        $cache = new Cache($adapter);
+        $telemetry = new class ($captured) extends TestTelemetry {
+            /**
+             * @param  array<int, array<string, mixed>>  $captured
+             */
+            public function __construct(public array &$captured) {}
+
+            public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): \Utopia\Telemetry\Counter
+            {
+                if ($name !== 'cache.load.total') {
+                    return parent::createCounter($name, $unit, $description, $advisory);
+                }
+                $captured = &$this->captured;
+                return $this->counters[$name] = new class ($captured) extends \Utopia\Telemetry\Counter {
+                    /**
+                     * @param  array<int, array<string, mixed>>  $captured
+                     */
+                    public function __construct(public array &$captured) {}
+
+                    public function add(float|int $amount, iterable $attributes = []): void
+                    {
+                        $this->captured[] = \is_array($attributes) ? $attributes : \iterator_to_array($attributes);
+                    }
+                };
+            }
+        };
+        $cache->setTelemetry($telemetry);
+
+        $cache->load('any', 60);
+
+        $this->assertSame('hit', $captured[0]['result']);
+    }
 }

--- a/tests/Cache/Unit/LoadResultsTelemetryTest.php
+++ b/tests/Cache/Unit/LoadResultsTelemetryTest.php
@@ -21,6 +21,7 @@ class LoadResultsTelemetryTest extends TestCase
         $cache->load('present', 60);
 
         $this->assertArrayHasKey('cache.load.total', $telemetry->counters);
+        /** @phpstan-ignore-next-line property.notFound */
         $this->assertCount(3, $telemetry->counters['cache.load.total']->values);
     }
 
@@ -29,11 +30,14 @@ class LoadResultsTelemetryTest extends TestCase
         $captured = [];
 
         $cache = new Cache(new Memory());
-        $telemetry = new class ($captured) extends TestTelemetry {
+        $telemetry = new class($captured) extends TestTelemetry
+        {
             /**
              * @param  array<int, array<string, mixed>>  $captured
              */
-            public function __construct(public array &$captured) {}
+            public function __construct(public array &$captured)
+            {
+            }
 
             public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): \Utopia\Telemetry\Counter
             {
@@ -41,11 +45,15 @@ class LoadResultsTelemetryTest extends TestCase
                     return parent::createCounter($name, $unit, $description, $advisory);
                 }
                 $captured = &$this->captured;
-                return $this->counters[$name] = new class ($captured) extends \Utopia\Telemetry\Counter {
+
+                return $this->counters[$name] = new class($captured) extends \Utopia\Telemetry\Counter
+                {
                     /**
                      * @param  array<int, array<string, mixed>>  $captured
                      */
-                    public function __construct(public array &$captured) {}
+                    public function __construct(public array &$captured)
+                    {
+                    }
 
                     public function add(float|int $amount, iterable $attributes = []): void
                     {
@@ -68,7 +76,8 @@ class LoadResultsTelemetryTest extends TestCase
     {
         $captured = [];
 
-        $adapter = new class extends Memory {
+        $adapter = new class extends Memory
+        {
             public function load(string $key, int $ttl, string $hash = ''): mixed
             {
                 return null;
@@ -76,11 +85,14 @@ class LoadResultsTelemetryTest extends TestCase
         };
 
         $cache = new Cache($adapter);
-        $telemetry = new class ($captured) extends TestTelemetry {
+        $telemetry = new class($captured) extends TestTelemetry
+        {
             /**
              * @param  array<int, array<string, mixed>>  $captured
              */
-            public function __construct(public array &$captured) {}
+            public function __construct(public array &$captured)
+            {
+            }
 
             public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): \Utopia\Telemetry\Counter
             {
@@ -88,11 +100,15 @@ class LoadResultsTelemetryTest extends TestCase
                     return parent::createCounter($name, $unit, $description, $advisory);
                 }
                 $captured = &$this->captured;
-                return $this->counters[$name] = new class ($captured) extends \Utopia\Telemetry\Counter {
+
+                return $this->counters[$name] = new class($captured) extends \Utopia\Telemetry\Counter
+                {
                     /**
                      * @param  array<int, array<string, mixed>>  $captured
                      */
-                    public function __construct(public array &$captured) {}
+                    public function __construct(public array &$captured)
+                    {
+                    }
 
                     public function add(float|int $amount, iterable $attributes = []): void
                     {

--- a/tests/Cache/Unit/LoadResultsTelemetryTest.php
+++ b/tests/Cache/Unit/LoadResultsTelemetryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Utopia\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\Memory;
+use Utopia\Cache\Cache;
+use Utopia\Telemetry\Adapter\Test as TestTelemetry;
+
+class LoadResultsTelemetryTest extends TestCase
+{
+    public function testLoadEmitsHitAndMissCounts(): void
+    {
+        $cache = new Cache(new Memory());
+        $telemetry = new TestTelemetry();
+        $cache->setTelemetry($telemetry);
+
+        $cache->load('missing', 60);
+        $cache->save('present', 'value');
+        $cache->load('present', 60);
+        $cache->load('present', 60);
+
+        $this->assertArrayHasKey('cache.load.total', $telemetry->counters);
+        $this->assertCount(3, $telemetry->counters['cache.load.total']->values);
+    }
+
+    public function testHitMissAttributesAreRecorded(): void
+    {
+        $captured = [];
+
+        $cache = new Cache(new Memory());
+        $telemetry = new class ($captured) extends TestTelemetry {
+            /**
+             * @param  array<int, array<string, mixed>>  $captured
+             */
+            public function __construct(public array &$captured) {}
+
+            public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): \Utopia\Telemetry\Counter
+            {
+                if ($name !== 'cache.load.total') {
+                    return parent::createCounter($name, $unit, $description, $advisory);
+                }
+                $captured = &$this->captured;
+                return $this->counters[$name] = new class ($captured) extends \Utopia\Telemetry\Counter {
+                    /**
+                     * @param  array<int, array<string, mixed>>  $captured
+                     */
+                    public function __construct(public array &$captured) {}
+
+                    public function add(float|int $amount, iterable $attributes = []): void
+                    {
+                        $this->captured[] = \is_array($attributes) ? $attributes : \iterator_to_array($attributes);
+                    }
+                };
+            }
+        };
+        $cache->setTelemetry($telemetry);
+
+        $cache->load('absent', 60);
+        $cache->save('here', 'value');
+        $cache->load('here', 60);
+
+        $results = \array_column($captured, 'result');
+        $this->assertSame(['miss', 'hit'], $results);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `cache.load.total{adapter, result=hit|miss}` counter so hitrate can be computed without exploding histogram cardinality across `le` buckets.
- Strict `=== false` check for the miss sentinel — cached `null` / `0` / `''` / `[]` now correctly count as hits.
- Fix `cache.redis_multiplexing.pending.depth`: the gauge was only sampled after enqueue (so its minimum reading was always 1) and never decremented on dequeue (so drained queues kept reporting stale depth). Switched to an `UpDownCounter` with `+1` on enqueue and `-1` on each dequeue (reader path and teardown).

## Out of scope (follow-ups)
- Per-prefix label on the operation counter (needs an allowlist mechanism).
- `cache_operation_errors_total{operation, reason}`.
- Multiplexing teardown counter + response-wait histogram.

## Test plan
- [x] `vendor/bin/phpunit --testsuite unit`
- [x] `vendor/bin/pint --test`
- [x] `vendor/bin/phpstan analyse --level max`
- [ ] Spot-check the new counter and the corrected pending-depth in an OpenTelemetry-backed deployment