### PR TITLE
fix: create telemetry instruments lazily on first use

### DIFF
--- a/src/Cache/Adapter/Redis/Multiplexing.php
+++ b/src/Cache/Adapter/Redis/Multiplexing.php
@@ -33,6 +33,8 @@ class Multiplexing implements Adapter, TelemetryFeature
      */
     private Lock $sendLock;
 
+    private Telemetry $telemetry;
+
     private ?UpDownCounter $pendingDepth = null;
 
     /**
@@ -77,7 +79,13 @@ class Multiplexing implements Adapter, TelemetryFeature
      */
     public function setTelemetry(Telemetry $telemetry): void
     {
-        $this->pendingDepth = $telemetry->createUpDownCounter(
+        $this->telemetry = $telemetry;
+        $this->pendingDepth = null;
+    }
+
+    private function getPendingDepth(): UpDownCounter
+    {
+        return $this->pendingDepth ??= $this->telemetry->createUpDownCounter(
             'cache.redis_multiplexing.pending.depth',
             description: 'Pending response channels awaiting RESP frames on the multiplexed connection.',
         );
@@ -228,7 +236,7 @@ class Multiplexing implements Adapter, TelemetryFeature
             $error = null;
 
             $context->pending->enqueue($response);
-            $this->pendingDepth?->add(1);
+            $this->getPendingDepth()->add(1);
             try {
                 $context->client->send(Client::encode($args));
             } catch (ConnectionException $sendError) {
@@ -340,7 +348,7 @@ class Multiplexing implements Adapter, TelemetryFeature
         while (! $context->pending->isEmpty()) {
             $ch = $context->pending->dequeue();
             if ($ch instanceof Channel) {
-                $this->pendingDepth?->add(-1);
+                $this->getPendingDepth()->add(-1);
                 $ch->push(new ConnectionError($error));
             }
         }
@@ -412,7 +420,7 @@ class Multiplexing implements Adapter, TelemetryFeature
                 // A complete frame implies a prior pending enqueue.
                 $waiting = $context->pending->isEmpty() ? null : $context->pending->dequeue();
                 if ($waiting instanceof Channel) {
-                    $this->pendingDepth?->add(-1);
+                    $this->getPendingDepth()->add(-1);
                     $waiting->push($value);
                 } else {
                     // Should never happen given the send-lock invariant. Log

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -16,6 +16,8 @@ class Cache
      */
     public bool $caseSensitive = false;
 
+    protected Telemetry $telemetry;
+
     /**
      * @var Histogram|null
      */
@@ -27,27 +29,39 @@ class Cache
     protected ?Counter $loadResults = null;
 
     /**
-     * Set telemetry adapter and create histograms for cache operations.
+     * Set telemetry adapter. Instruments are created lazily on first use to
+     * avoid emitting empty data point streams on every export interval.
      *
      * @param  Telemetry  $telemetry
      */
     public function setTelemetry(Telemetry $telemetry): void
     {
-        $this->operationDuration = $telemetry->createHistogram(
+        $this->telemetry = $telemetry;
+        $this->operationDuration = null;
+        $this->loadResults = null;
+
+        if ($this->adapter instanceof Feature\Telemetry) {
+            $this->adapter->setTelemetry($telemetry);
+        }
+    }
+
+    private function getOperationDuration(): Histogram
+    {
+        return $this->operationDuration ??= $this->telemetry->createHistogram(
             'cache.operation.duration',
             's',
             null,
             ['ExplicitBucketBoundaries' => [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1]]
         );
-        $this->loadResults = $telemetry->createCounter(
+    }
+
+    private function getLoadResults(): Counter
+    {
+        return $this->loadResults ??= $this->telemetry->createCounter(
             'cache.load.total',
             null,
             'Cache load operations broken down by hit/miss result.',
         );
-
-        if ($this->adapter instanceof Feature\Telemetry) {
-            $this->adapter->setTelemetry($telemetry);
-        }
     }
 
     /**
@@ -58,7 +72,7 @@ class Cache
     public function __construct(Adapter $adapter)
     {
         $this->adapter = $adapter;
-        $this->setTelemetry(new NoTelemetry());
+        $this->telemetry = new NoTelemetry();
     }
 
     /**
@@ -89,11 +103,11 @@ class Cache
         $result = $this->adapter->load($key, $ttl, $hash);
         $duration = microtime(true) - $start;
         $adapterName = $this->adapter->getName($key);
-        $this->operationDuration?->record($duration, [
+        $this->getOperationDuration()->record($duration, [
             'operation' => 'load',
             'adapter' => $adapterName,
         ]);
-        $this->loadResults?->add(1, [
+        $this->getLoadResults()->add(1, [
             'adapter' => $adapterName,
             'result' => $result === false ? 'miss' : 'hit',
         ]);
@@ -119,7 +133,7 @@ class Cache
             return $this->adapter->save($key, $data, $hash);
         } finally {
             $duration = microtime(true) - $start;
-            $this->operationDuration?->record($duration, [
+            $this->getOperationDuration()->record($duration, [
                 'operation' => 'save',
                 'adapter' => $this->adapter->getName($key),
             ]);
@@ -141,7 +155,7 @@ class Cache
         $start = microtime(true);
         $result = $this->adapter->touch($key, $hash);
         $duration = microtime(true) - $start;
-        $this->operationDuration?->record($duration, [
+        $this->getOperationDuration()->record($duration, [
             'operation' => 'touch',
             'adapter' => $this->adapter->getName($key),
         ]);
@@ -162,7 +176,7 @@ class Cache
         $start = microtime(true);
         $result = $this->adapter->list($key);
         $duration = microtime(true) - $start;
-        $this->operationDuration?->record($duration, [
+        $this->getOperationDuration()->record($duration, [
             'operation' => 'list',
             'adapter' => $this->adapter->getName($key),
         ]);
@@ -185,7 +199,7 @@ class Cache
         $start = microtime(true);
         $result = $this->adapter->purge($key, $hash);
         $duration = microtime(true) - $start;
-        $this->operationDuration?->record($duration, [
+        $this->getOperationDuration()->record($duration, [
             'operation' => 'purge',
             'adapter' => $this->adapter->getName($key),
         ]);
@@ -203,7 +217,7 @@ class Cache
         $start = microtime(true);
         $result = $this->adapter->flush();
         $duration = microtime(true) - $start;
-        $this->operationDuration?->record($duration, [
+        $this->getOperationDuration()->record($duration, [
             'operation' => 'flush',
             'adapter' => $this->adapter->getName(),
         ]);
@@ -231,7 +245,7 @@ class Cache
         $start = microtime(true);
         $result = $this->adapter->getSize();
         $duration = microtime(true) - $start;
-        $this->operationDuration?->record($duration, [
+        $this->getOperationDuration()->record($duration, [
             'operation' => 'size',
             'adapter' => $this->adapter->getName(),
         ]);

--- a/tests/Cache/E2E/TelemetryTest.php
+++ b/tests/Cache/E2E/TelemetryTest.php
@@ -32,6 +32,6 @@ class TelemetryTest extends TestCase
         $cache->setTelemetry($telemetry);
 
         $this->assertSame($telemetry, $adapter->telemetry);
-        $this->assertEquals(2, $adapter->calls);
+        $this->assertEquals(1, $adapter->calls);
     }
 }


### PR DESCRIPTION
## Summary
- Defer creation of `cache.operation.duration`, `cache.load.total`, and `cache.redis_multiplexing.pending.depth` until first record/add
- `setTelemetry()` now just stores the adapter; instruments materialize on demand via private getters

## Why
The OTel SDK walks all registered instruments on every periodic export and emits a stream per instrument — empty data points if nothing was recorded. Eager registration in `setTelemetry()` produced empty streams for cache instances that never saw traffic.

## Test plan
- [ ] `composer test` (existing telemetry tests exercise `load()`/`save()` before asserting, so they still observe the instrument)
- [ ] Confirm an OTel-wired Cache instance with no traffic emits no cache.* streams