### PR TITLE
Fence Redis cache fills after invalidation

### DIFF
--- a/src/Cache/Adapter/CircuitBreaker.php
+++ b/src/Cache/Adapter/CircuitBreaker.php
@@ -4,10 +4,11 @@ namespace Utopia\Cache\Adapter;
 
 use Utopia\Cache\Adapter;
 use Utopia\Cache\Feature;
+use Utopia\Cache\Token;
 use Utopia\CircuitBreaker\CircuitBreaker as UtopiaCircuitBreaker;
 use Utopia\Telemetry\Adapter as Telemetry;
 
-class CircuitBreaker implements Adapter, Feature\Telemetry
+class CircuitBreaker implements Adapter, Feature\FencedFill, Feature\Telemetry
 {
     public function __construct(
         private readonly Adapter $adapter,
@@ -37,8 +38,29 @@ class CircuitBreaker implements Adapter, Feature\Telemetry
         return $this->delegate(__FUNCTION__, \func_get_args(), false);
     }
 
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+    {
+        if (! ($this->adapter instanceof Feature\FencedFill)) {
+            return $this->load($key, $ttl, $hash);
+        }
+
+        return $this->delegate(__FUNCTION__, \func_get_args(), false);
+    }
+
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
     {
+        /** @var bool|string|array<int|string, mixed> $result */
+        $result = $this->delegate(__FUNCTION__, \func_get_args(), false);
+
+        return $result;
+    }
+
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+    {
+        if (! ($this->adapter instanceof Feature\FencedFill)) {
+            return false;
+        }
+
         /** @var bool|string|array<int|string, mixed> $result */
         $result = $this->delegate(__FUNCTION__, \func_get_args(), false);
 

--- a/src/Cache/Adapter/Pool.php
+++ b/src/Cache/Adapter/Pool.php
@@ -3,9 +3,11 @@
 namespace Utopia\Cache\Adapter;
 
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Feature\FencedFill;
+use Utopia\Cache\Token;
 use Utopia\Pools\Pool as UtopiaPool;
 
-class Pool implements Adapter
+class Pool implements Adapter, FencedFill
 {
     /**
      * @var UtopiaPool<covariant Adapter>
@@ -49,12 +51,39 @@ class Pool implements Adapter
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
 
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+    {
+        return $this->pool->use(function (Adapter $adapter) use ($key, $ttl, $hash) {
+            if ($adapter instanceof FencedFill) {
+                return $adapter->loadFenced($key, $ttl, $hash);
+            }
+
+            return $adapter->load($key, $ttl, $hash);
+        });
+    }
+
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
     {
         /**
          * @var bool|string|array<mixed> $result
          */
         $result = $this->delegate(__FUNCTION__, \func_get_args());
+
+        return $result;
+    }
+
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+    {
+        /**
+         * @var bool|string|array<mixed> $result
+         */
+        $result = $this->pool->use(function (Adapter $adapter) use ($key, $data, $token, $hash) {
+            if (! ($adapter instanceof FencedFill)) {
+                return false;
+            }
+
+            return $adapter->saveFenced($key, $data, $token, $hash);
+        });
 
         return $result;
     }

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -190,6 +190,9 @@ local tombstone = redis.call('GET', KEYS[2])
 local globalTombstone = redis.call('GET', KEYS[3])
 local ok, token = pcall(cjson.decode, ARGV[2])
 if ok and type(token) == 'table' and token['state'] == 'absent' then
+    if type(token['time']) ~= 'number' or token['time'] + tonumber(ARGV[4]) <= tonumber(ARGV[5]) then
+        return 0
+    end
     if not current and not tombstone and not globalTombstone then
         redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
         return 1
@@ -214,7 +217,7 @@ return 0
 LUA;
 
         try {
-            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value], 3));
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value, (string) self::TOKEN_TTL, (string) \time()], 3));
 
             return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;
         } catch (Throwable $th) {

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -7,10 +7,14 @@ use Redis as Client;
 use Throwable;
 use Utopia\Cache\Adapter;
 use Utopia\Cache\Adapter\Redis\Envelope;
+use Utopia\Cache\Feature\FencedFill;
 use Utopia\Cache\Feature\Retryable;
+use Utopia\Cache\Token;
 
-class Redis implements Adapter, Retryable
+class Redis implements Adapter, FencedFill, Retryable
 {
+    private const int TOKEN_TTL = 60;
+
     /**
      * @var Client
      */
@@ -97,17 +101,36 @@ class Redis implements Adapter, Retryable
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
+        $result = $this->loadFenced($key, $ttl, $hash);
+
+        return $result instanceof Token ? false : $result;
+    }
+
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+    {
         if (empty($hash)) {
             $hash = $key;
         }
 
-        $redis_string = $this->execute(fn () => $this->redis->hGet($key, $hash));
-
-        if (! is_string($redis_string)) {
+        $result = $this->loadOrToken($key, $hash, $ttl);
+        if (! \is_array($result) || ! isset($result[0])) {
             return false;
         }
 
-        return Envelope::decode($redis_string, $ttl, time());
+        $status = $result[0];
+        if (! \is_int($status) && ! \is_string($status)) {
+            return false;
+        }
+
+        if ((int) $status === 2 && isset($result[1]) && \is_string($result[1])) {
+            return new Token($result[1]);
+        }
+
+        if ((int) $status === 1 && isset($result[1]) && \is_string($result[1])) {
+            return Envelope::decode($result[1], $ttl, time());
+        }
+
+        return false;
     }
 
     /**
@@ -128,9 +151,72 @@ class Redis implements Adapter, Retryable
 
         try {
             $value = Envelope::encode($data, time());
-            $this->execute(fn () => $this->redis->hSet($key, $hash, $value));
+            $script = <<<'LUA'
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('DEL', KEYS[2])
+return 1
+LUA;
+
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $hash, $value], 2));
+            if ((! \is_int($result) && ! \is_string($result)) || (int) $result !== 1) {
+                return false;
+            }
 
             return $data;
+        } catch (Throwable $th) {
+            return false;
+        }
+    }
+
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+    {
+        if (empty($key) || empty($data)) {
+            return false;
+        }
+
+        if (empty($hash)) {
+            $hash = $key;
+        }
+
+        try {
+            $value = Envelope::encode($data, time());
+        } catch (Throwable $th) {
+            return false;
+        }
+
+        $script = <<<'LUA'
+local current = redis.call('HGET', KEYS[1], ARGV[1])
+local tombstone = redis.call('GET', KEYS[2])
+local globalTombstone = redis.call('GET', KEYS[3])
+local ok, token = pcall(cjson.decode, ARGV[2])
+if ok and type(token) == 'table' and token['state'] == 'absent' then
+    if not current and not tombstone and not globalTombstone then
+        redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+        return 1
+    end
+    return 0
+end
+if current == ARGV[2] then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    redis.call('DEL', KEYS[2])
+    return 1
+end
+if not current and tombstone == ARGV[2] and not globalTombstone then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    redis.call('DEL', KEYS[2])
+    return 1
+end
+if not current and not tombstone and globalTombstone == ARGV[2] then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    return 1
+end
+return 0
+LUA;
+
+        try {
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value], 3));
+
+            return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;
         } catch (Throwable $th) {
             return false;
         }
@@ -184,11 +270,99 @@ class Redis implements Adapter, Retryable
      */
     public function purge(string $key, string $hash = ''): bool
     {
-        if (! empty($hash)) {
-            return (bool) $this->execute(fn () => $this->redis->hdel($key, $hash));
+        $token = $this->createToken();
+        if ($token === false) {
+            return false;
         }
 
-        return (bool) $this->execute(fn () => $this->redis->del($key));
+        if (! empty($hash)) {
+            $script = <<<'LUA'
+redis.call('HDEL', KEYS[1], ARGV[1])
+redis.call('SETEX', KEYS[2], ARGV[2], ARGV[3])
+return 1
+LUA;
+
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $hash, (string) self::TOKEN_TTL, $token->value], 2));
+
+            return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+        }
+
+        $script = <<<'LUA'
+redis.call('DEL', KEYS[1])
+redis.call('SETEX', KEYS[2], ARGV[1], ARGV[2])
+return 1
+LUA;
+
+        $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, '*'), (string) self::TOKEN_TTL, $token->value], 2));
+
+        return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+    }
+
+    /**
+     * @return array<int, mixed>|false
+     */
+    private function loadOrToken(string $key, string $hash, int $ttl): array|false
+    {
+        $token = $this->createToken('absent');
+        if ($token === false) {
+            return false;
+        }
+
+        $script = <<<'LUA'
+local value = redis.call('HGET', KEYS[1], ARGV[1])
+if value then
+    local ok, payload = pcall(cjson.decode, value)
+    if ok and type(payload) == 'table' then
+        if payload['data'] ~= nil and type(payload['time']) == 'number' then
+            if payload['time'] + tonumber(ARGV[2]) > tonumber(ARGV[3]) then
+                return {1, value}
+            end
+            return {2, value}
+        end
+        if payload['token'] ~= nil and payload['data'] == nil then
+            return {2, value}
+        end
+    end
+    return {2, value}
+end
+
+local tombstone = redis.call('GET', KEYS[2])
+if tombstone then
+    return {2, tombstone}
+end
+local globalTombstone = redis.call('GET', KEYS[3])
+if globalTombstone then
+    return {2, globalTombstone}
+end
+return {2, ARGV[4]}
+LUA;
+
+        $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, (string) $ttl, (string) \time(), $token->value], 3));
+
+        return \is_array($result) ? $result : false;
+    }
+
+    private function createToken(string $state = 'token'): Token|false
+    {
+        try {
+            return new Token(json_encode([
+                'time' => \time(),
+                'state' => $state,
+                'token' => \bin2hex(\random_bytes(16)),
+            ], flags: JSON_THROW_ON_ERROR));
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function getTombstoneKey(string $key, string $hash): string
+    {
+        $tag = $key;
+        if (\preg_match('/\{([^{}]+)\}/', $key, $matches) === 1) {
+            $tag = $matches[1];
+        }
+
+        return '{'.$tag.'}:utopia-cache-token:'.\hash('sha256', $key."\0".$hash);
     }
 
     /**

--- a/src/Cache/Adapter/Redis.php
+++ b/src/Cache/Adapter/Redis.php
@@ -188,9 +188,13 @@ LUA;
 local current = redis.call('HGET', KEYS[1], ARGV[1])
 local tombstone = redis.call('GET', KEYS[2])
 local globalTombstone = redis.call('GET', KEYS[3])
+local lastFlush = redis.call('GET', KEYS[4])
 local ok, token = pcall(cjson.decode, ARGV[2])
 if ok and type(token) == 'table' and token['state'] == 'absent' then
     if type(token['time']) ~= 'number' or token['time'] + tonumber(ARGV[4]) <= tonumber(ARGV[5]) then
+        return 0
+    end
+    if lastFlush and tonumber(lastFlush) >= token['time'] then
         return 0
     end
     if not current and not tombstone and not globalTombstone then
@@ -217,7 +221,7 @@ return 0
 LUA;
 
         try {
-            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value, (string) self::TOKEN_TTL, (string) \time()], 3));
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $this->getFlushKey(), $hash, $token->value, $value, (string) self::TOKEN_TTL, (string) \time()], 4));
 
             return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;
         } catch (Throwable $th) {
@@ -373,7 +377,20 @@ LUA;
      */
     public function flush(): bool
     {
-        return (bool) $this->execute(fn () => $this->redis->flushDB());
+        $script = <<<'LUA'
+redis.call('FLUSHDB')
+redis.call('SETEX', KEYS[1], ARGV[1], ARGV[2])
+return 1
+LUA;
+
+        $result = $this->execute(fn () => $this->redis->eval($script, [$this->getFlushKey(), (string) self::TOKEN_TTL, (string) \time()], 1));
+
+        return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+    }
+
+    private function getFlushKey(): string
+    {
+        return 'utopia-cache-flush-token';
     }
 
     /**

--- a/src/Cache/Adapter/Redis/Multiplexing.php
+++ b/src/Cache/Adapter/Redis/Multiplexing.php
@@ -199,6 +199,9 @@ local tombstone = redis.call('GET', KEYS[2])
 local globalTombstone = redis.call('GET', KEYS[3])
 local ok, token = pcall(cjson.decode, ARGV[2])
 if ok and type(token) == 'table' and token['state'] == 'absent' then
+    if type(token['time']) ~= 'number' or token['time'] + tonumber(ARGV[4]) <= tonumber(ARGV[5]) then
+        return 0
+    end
     if not current and not tombstone and not globalTombstone then
         redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
         return 1
@@ -232,6 +235,8 @@ LUA;
             $hash,
             $token->value,
             $value,
+            (string) self::TOKEN_TTL,
+            (string) \time(),
         ]);
 
         return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;

--- a/src/Cache/Adapter/Redis/Multiplexing.php
+++ b/src/Cache/Adapter/Redis/Multiplexing.php
@@ -8,7 +8,9 @@ use Swoole\Coroutine\Channel;
 use Swoole\Coroutine\Lock;
 use Throwable;
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Feature\FencedFill;
 use Utopia\Cache\Feature\Telemetry as TelemetryFeature;
+use Utopia\Cache\Token;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
 use Utopia\Telemetry\UpDownCounter;
@@ -23,8 +25,10 @@ use Utopia\Telemetry\UpDownCounter;
  * single reader coroutine parses inbound frames and dispatches each one to
  * the next pending Channel, exploiting Redis's guarantee of in-order replies.
  */
-class Multiplexing implements Adapter, TelemetryFeature
+class Multiplexing implements Adapter, FencedFill, TelemetryFeature
 {
+    private const int TOKEN_TTL = 60;
+
     private ?ConnectionContext $connection = null;
 
     /**
@@ -102,17 +106,36 @@ class Multiplexing implements Adapter, TelemetryFeature
 
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
+        $result = $this->loadFenced($key, $ttl, $hash);
+
+        return $result instanceof Token ? false : $result;
+    }
+
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+    {
         if (empty($hash)) {
             $hash = $key;
         }
 
-        $value = $this->command(['HGET', $key, $hash]);
-
-        if (! is_string($value)) {
+        $result = $this->loadOrToken($key, $hash, $ttl);
+        if (! \is_array($result) || ! isset($result[0])) {
             return false;
         }
 
-        return Envelope::decode($value, $ttl, time());
+        $status = $result[0];
+        if (! \is_int($status) && ! \is_string($status)) {
+            return false;
+        }
+
+        if ((int) $status === 2 && isset($result[1]) && \is_string($result[1])) {
+            return new Token($result[1]);
+        }
+
+        if ((int) $status === 1 && isset($result[1]) && \is_string($result[1])) {
+            return Envelope::decode($result[1], $ttl, time());
+        }
+
+        return false;
     }
 
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
@@ -125,10 +148,93 @@ class Multiplexing implements Adapter, TelemetryFeature
             $hash = $key;
         }
 
-        $value = Envelope::encode($data, time());
-        $this->command(['HSET', $key, $hash, $value]);
+        try {
+            $value = Envelope::encode($data, time());
+        } catch (Throwable) {
+            return false;
+        }
+
+        $script = <<<'LUA'
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('DEL', KEYS[2])
+return 1
+LUA;
+
+        $result = $this->command([
+            'EVAL',
+            $script,
+            '2',
+            $key,
+            $this->getTombstoneKey($key, $hash),
+            $hash,
+            $value,
+        ]);
+
+        if ((! \is_int($result) && ! \is_string($result)) || (int) $result !== 1) {
+            return false;
+        }
 
         return $data;
+    }
+
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+    {
+        if (empty($key) || empty($data)) {
+            return false;
+        }
+
+        if (empty($hash)) {
+            $hash = $key;
+        }
+
+        try {
+            $value = Envelope::encode($data, time());
+        } catch (Throwable) {
+            return false;
+        }
+
+        $script = <<<'LUA'
+local current = redis.call('HGET', KEYS[1], ARGV[1])
+local tombstone = redis.call('GET', KEYS[2])
+local globalTombstone = redis.call('GET', KEYS[3])
+local ok, token = pcall(cjson.decode, ARGV[2])
+if ok and type(token) == 'table' and token['state'] == 'absent' then
+    if not current and not tombstone and not globalTombstone then
+        redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+        return 1
+    end
+    return 0
+end
+if current == ARGV[2] then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    redis.call('DEL', KEYS[2])
+    return 1
+end
+if not current and tombstone == ARGV[2] and not globalTombstone then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    redis.call('DEL', KEYS[2])
+    return 1
+end
+if not current and not tombstone and globalTombstone == ARGV[2] then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    return 1
+end
+return 0
+LUA;
+
+        $result = $this->command([
+            'EVAL',
+            $script,
+            '3',
+            $key,
+            $this->getTombstoneKey($key, $hash),
+            $this->getTombstoneKey($key, '*'),
+            $hash,
+            $token->value,
+            $value,
+        ]);
+
+        return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;
     }
 
     public function touch(string $key, string $hash = ''): bool
@@ -166,11 +272,127 @@ class Multiplexing implements Adapter, TelemetryFeature
 
     public function purge(string $key, string $hash = ''): bool
     {
-        if (! empty($hash)) {
-            return (bool) $this->command(['HDEL', $key, $hash]);
+        $token = $this->createToken();
+        if ($token === false) {
+            return false;
         }
 
-        return (bool) $this->command(['DEL', $key]);
+        if (! empty($hash)) {
+            $script = <<<'LUA'
+redis.call('HDEL', KEYS[1], ARGV[1])
+redis.call('SETEX', KEYS[2], ARGV[2], ARGV[3])
+return 1
+LUA;
+
+            $result = $this->command([
+                'EVAL',
+                $script,
+                '2',
+                $key,
+                $this->getTombstoneKey($key, $hash),
+                $hash,
+                (string) self::TOKEN_TTL,
+                $token->value,
+            ]);
+
+            return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+        }
+
+        $script = <<<'LUA'
+redis.call('DEL', KEYS[1])
+redis.call('SETEX', KEYS[2], ARGV[1], ARGV[2])
+return 1
+LUA;
+
+        $result = $this->command([
+            'EVAL',
+            $script,
+            '2',
+            $key,
+            $this->getTombstoneKey($key, '*'),
+            (string) self::TOKEN_TTL,
+            $token->value,
+        ]);
+
+        return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+    }
+
+    /**
+     * @return array<int, mixed>|false
+     */
+    private function loadOrToken(string $key, string $hash, int $ttl): array|false
+    {
+        $token = $this->createToken('absent');
+        if ($token === false) {
+            return false;
+        }
+
+        $script = <<<'LUA'
+local value = redis.call('HGET', KEYS[1], ARGV[1])
+if value then
+    local ok, payload = pcall(cjson.decode, value)
+    if ok and type(payload) == 'table' then
+        if payload['data'] ~= nil and type(payload['time']) == 'number' then
+            if payload['time'] + tonumber(ARGV[2]) > tonumber(ARGV[3]) then
+                return {1, value}
+            end
+            return {2, value}
+        end
+        if payload['token'] ~= nil and payload['data'] == nil then
+            return {2, value}
+        end
+    end
+    return {2, value}
+end
+
+local tombstone = redis.call('GET', KEYS[2])
+if tombstone then
+    return {2, tombstone}
+end
+local globalTombstone = redis.call('GET', KEYS[3])
+if globalTombstone then
+    return {2, globalTombstone}
+end
+return {2, ARGV[4]}
+LUA;
+
+        $result = $this->command([
+            'EVAL',
+            $script,
+            '3',
+            $key,
+            $this->getTombstoneKey($key, $hash),
+            $this->getTombstoneKey($key, '*'),
+            $hash,
+            (string) $ttl,
+            (string) \time(),
+            $token->value,
+        ]);
+
+        return \is_array($result) ? $result : false;
+    }
+
+    private function createToken(string $state = 'token'): Token|false
+    {
+        try {
+            return new Token(json_encode([
+                'time' => \time(),
+                'state' => $state,
+                'token' => \bin2hex(\random_bytes(16)),
+            ], flags: JSON_THROW_ON_ERROR));
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function getTombstoneKey(string $key, string $hash): string
+    {
+        $tag = $key;
+        if (\preg_match('/\{([^{}]+)\}/', $key, $matches) === 1) {
+            $tag = $matches[1];
+        }
+
+        return '{'.$tag.'}:utopia-cache-token:'.\hash('sha256', $key."\0".$hash);
     }
 
     public function flush(): bool

--- a/src/Cache/Adapter/Redis/Multiplexing.php
+++ b/src/Cache/Adapter/Redis/Multiplexing.php
@@ -197,9 +197,13 @@ LUA;
 local current = redis.call('HGET', KEYS[1], ARGV[1])
 local tombstone = redis.call('GET', KEYS[2])
 local globalTombstone = redis.call('GET', KEYS[3])
+local lastFlush = redis.call('GET', KEYS[4])
 local ok, token = pcall(cjson.decode, ARGV[2])
 if ok and type(token) == 'table' and token['state'] == 'absent' then
     if type(token['time']) ~= 'number' or token['time'] + tonumber(ARGV[4]) <= tonumber(ARGV[5]) then
+        return 0
+    end
+    if lastFlush and tonumber(lastFlush) >= token['time'] then
         return 0
     end
     if not current and not tombstone and not globalTombstone then
@@ -232,6 +236,7 @@ LUA;
             $key,
             $this->getTombstoneKey($key, $hash),
             $this->getTombstoneKey($key, '*'),
+            $this->getFlushKey(),
             $hash,
             $token->value,
             $value,
@@ -402,7 +407,27 @@ LUA;
 
     public function flush(): bool
     {
-        return $this->command(['FLUSHDB']) === 'OK';
+        $script = <<<'LUA'
+redis.call('FLUSHDB')
+redis.call('SETEX', KEYS[1], ARGV[1], ARGV[2])
+return 1
+LUA;
+
+        $result = $this->command([
+            'EVAL',
+            $script,
+            '1',
+            $this->getFlushKey(),
+            (string) self::TOKEN_TTL,
+            (string) \time(),
+        ]);
+
+        return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+    }
+
+    private function getFlushKey(): string
+    {
+        return 'utopia-cache-flush-token';
     }
 
     public function ping(): bool

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -196,6 +196,9 @@ local tombstone = redis.call('GET', KEYS[2])
 local globalTombstone = redis.call('GET', KEYS[3])
 local ok, token = pcall(cjson.decode, ARGV[2])
 if ok and type(token) == 'table' and token['state'] == 'absent' then
+    if type(token['time']) ~= 'number' or token['time'] + tonumber(ARGV[4]) <= tonumber(ARGV[5]) then
+        return 0
+    end
     if not current and not tombstone and not globalTombstone then
         redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
         return 1
@@ -220,7 +223,7 @@ return 0
 LUA;
 
         try {
-            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value], 3));
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value, (string) self::TOKEN_TTL, (string) \time()], 3));
 
             return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;
         } catch (Throwable $th) {

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -6,10 +6,15 @@ use Exception;
 use RedisCluster as Client;
 use Throwable;
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Adapter\Redis\Envelope;
+use Utopia\Cache\Feature\FencedFill;
 use Utopia\Cache\Feature\Retryable;
+use Utopia\Cache\Token;
 
-class RedisCluster implements Adapter, Retryable
+class RedisCluster implements Adapter, FencedFill, Retryable
 {
+    private const int TOKEN_TTL = 60;
+
     /**
      * @var Client
      */
@@ -97,22 +102,33 @@ class RedisCluster implements Adapter, Retryable
      */
     public function load(string $key, int $ttl, string $hash = ''): mixed
     {
+        $result = $this->loadFenced($key, $ttl, $hash);
+
+        return $result instanceof Token ? false : $result;
+    }
+
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+    {
         if (empty($hash)) {
             $hash = $key;
         }
 
-        /** @var string|false */
-        $redis_string = $this->execute(fn () => $this->redis->hGet($key, $hash));
-
-        if ($redis_string === false || ! is_string($redis_string)) {
+        $result = $this->loadOrToken($key, $hash, $ttl);
+        if (! \is_array($result) || ! isset($result[0])) {
             return false;
         }
 
-        /** @var array{time: int, data: string} $cache */
-        $cache = json_decode($redis_string, true);
+        $status = $result[0];
+        if (! \is_int($status) && ! \is_string($status)) {
+            return false;
+        }
 
-        if ($cache['time'] + $ttl > time()) { // Cache is valid
-            return $cache['data'];
+        if ((int) $status === 2 && isset($result[1]) && \is_string($result[1])) {
+            return new Token($result[1]);
+        }
+
+        if ((int) $status === 1 && isset($result[1]) && \is_string($result[1])) {
+            return Envelope::decode($result[1], $ttl, time());
         }
 
         return false;
@@ -135,18 +151,78 @@ class RedisCluster implements Adapter, Retryable
         }
 
         try {
-            $value = json_encode([
-                'time' => \time(),
-                'data' => $data,
-            ], flags: JSON_THROW_ON_ERROR);
+            $value = Envelope::encode($data, time());
         } catch (Throwable $th) {
             return false;
         }
 
         try {
-            $this->execute(fn () => $this->redis->hSet($key, $hash, $value));
+            $script = <<<'LUA'
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('DEL', KEYS[2])
+return 1
+LUA;
+
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $hash, $value], 2));
+            if ((! \is_int($result) && ! \is_string($result)) || (int) $result !== 1) {
+                return false;
+            }
 
             return $data;
+        } catch (Throwable $th) {
+            return false;
+        }
+    }
+
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+    {
+        if (empty($key) || empty($data)) {
+            return false;
+        }
+
+        if (empty($hash)) {
+            $hash = $key;
+        }
+
+        try {
+            $value = Envelope::encode($data, time());
+        } catch (Throwable $th) {
+            return false;
+        }
+
+        $script = <<<'LUA'
+local current = redis.call('HGET', KEYS[1], ARGV[1])
+local tombstone = redis.call('GET', KEYS[2])
+local globalTombstone = redis.call('GET', KEYS[3])
+local ok, token = pcall(cjson.decode, ARGV[2])
+if ok and type(token) == 'table' and token['state'] == 'absent' then
+    if not current and not tombstone and not globalTombstone then
+        redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+        return 1
+    end
+    return 0
+end
+if current == ARGV[2] then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    redis.call('DEL', KEYS[2])
+    return 1
+end
+if not current and tombstone == ARGV[2] and not globalTombstone then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    redis.call('DEL', KEYS[2])
+    return 1
+end
+if not current and not tombstone and globalTombstone == ARGV[2] then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    return 1
+end
+return 0
+LUA;
+
+        try {
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value], 3));
+
+            return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;
         } catch (Throwable $th) {
             return false;
         }
@@ -170,12 +246,8 @@ class RedisCluster implements Adapter, Retryable
             return false;
         }
 
-        try {
-            /** @var array{time: int, data: mixed} $cache */
-            $cache = json_decode($redis_string, true, flags: JSON_THROW_ON_ERROR);
-            $cache['time'] = time();
-            $value = json_encode($cache, flags: JSON_THROW_ON_ERROR);
-        } catch (Throwable $th) {
+        $value = Envelope::touch($redis_string, time());
+        if ($value === false) {
             return false;
         }
 
@@ -205,11 +277,99 @@ class RedisCluster implements Adapter, Retryable
      */
     public function purge(string $key, string $hash = ''): bool
     {
-        if (! empty($hash)) {
-            return (bool) $this->execute(fn () => $this->redis->hdel($key, $hash));
+        $token = $this->createToken();
+        if ($token === false) {
+            return false;
         }
 
-        return (bool) $this->execute(fn () => $this->redis->del($key));
+        if (! empty($hash)) {
+            $script = <<<'LUA'
+redis.call('HDEL', KEYS[1], ARGV[1])
+redis.call('SETEX', KEYS[2], ARGV[2], ARGV[3])
+return 1
+LUA;
+
+            $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $hash, (string) self::TOKEN_TTL, $token->value], 2));
+
+            return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+        }
+
+        $script = <<<'LUA'
+redis.call('DEL', KEYS[1])
+redis.call('SETEX', KEYS[2], ARGV[1], ARGV[2])
+return 1
+LUA;
+
+        $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, '*'), (string) self::TOKEN_TTL, $token->value], 2));
+
+        return (\is_int($result) || \is_string($result)) && (int) $result === 1;
+    }
+
+    /**
+     * @return array<int, mixed>|false
+     */
+    private function loadOrToken(string $key, string $hash, int $ttl): array|false
+    {
+        $token = $this->createToken('absent');
+        if ($token === false) {
+            return false;
+        }
+
+        $script = <<<'LUA'
+local value = redis.call('HGET', KEYS[1], ARGV[1])
+if value then
+    local ok, payload = pcall(cjson.decode, value)
+    if ok and type(payload) == 'table' then
+        if payload['data'] ~= nil and type(payload['time']) == 'number' then
+            if payload['time'] + tonumber(ARGV[2]) > tonumber(ARGV[3]) then
+                return {1, value}
+            end
+            return {2, value}
+        end
+        if payload['token'] ~= nil and payload['data'] == nil then
+            return {2, value}
+        end
+    end
+    return {2, value}
+end
+
+local tombstone = redis.call('GET', KEYS[2])
+if tombstone then
+    return {2, tombstone}
+end
+local globalTombstone = redis.call('GET', KEYS[3])
+if globalTombstone then
+    return {2, globalTombstone}
+end
+return {2, ARGV[4]}
+LUA;
+
+        $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, (string) $ttl, (string) \time(), $token->value], 3));
+
+        return \is_array($result) ? $result : false;
+    }
+
+    private function createToken(string $state = 'token'): Token|false
+    {
+        try {
+            return new Token(json_encode([
+                'time' => \time(),
+                'state' => $state,
+                'token' => \bin2hex(\random_bytes(16)),
+            ], flags: JSON_THROW_ON_ERROR));
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function getTombstoneKey(string $key, string $hash): string
+    {
+        $tag = $key;
+        if (\preg_match('/\{([^{}]+)\}/', $key, $matches) === 1) {
+            $tag = $matches[1];
+        }
+
+        return '{'.$tag.'}:utopia-cache-token:'.\hash('sha256', $key."\0".$hash);
     }
 
     /**

--- a/src/Cache/Adapter/RedisCluster.php
+++ b/src/Cache/Adapter/RedisCluster.php
@@ -190,6 +190,11 @@ LUA;
             return false;
         }
 
+        $tokenTime = $this->getAbsentTokenTime($token);
+        if ($tokenTime !== null && $this->wasFlushedAfter($tokenTime)) {
+            return false;
+        }
+
         $script = <<<'LUA'
 local current = redis.call('HGET', KEYS[1], ARGV[1])
 local tombstone = redis.call('GET', KEYS[2])
@@ -224,8 +229,17 @@ LUA;
 
         try {
             $result = $this->execute(fn () => $this->redis->eval($script, [$key, $this->getTombstoneKey($key, $hash), $this->getTombstoneKey($key, '*'), $hash, $token->value, $value, (string) self::TOKEN_TTL, (string) \time()], 3));
+            if ((! \is_int($result) && ! \is_string($result)) || (int) $result !== 1) {
+                return false;
+            }
 
-            return (\is_int($result) || \is_string($result)) && (int) $result === 1 ? $data : false;
+            if ($tokenTime !== null && $this->wasFlushedAfter($tokenTime)) {
+                $this->deleteIfCurrent($key, $hash, $value);
+
+                return false;
+            }
+
+            return $data;
         } catch (Throwable $th) {
             return false;
         }
@@ -380,7 +394,7 @@ LUA;
      */
     public function flush(): bool
     {
-        return (bool) $this->execute(function () {
+        $flushed = (bool) $this->execute(function () {
             /** @var array<string> $masters */
             $masters = $this->redis->_masters();
             foreach ($masters as $master) {
@@ -389,6 +403,51 @@ LUA;
 
             return true;
         });
+
+        if (! $flushed) {
+            return false;
+        }
+
+        return (bool) $this->execute(fn () => $this->redis->setex($this->getFlushKey(), self::TOKEN_TTL, (string) \time()));
+    }
+
+    private function getAbsentTokenTime(Token $token): ?int
+    {
+        try {
+            $decoded = json_decode($token->value, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (! \is_array($decoded) || ($decoded['state'] ?? null) !== 'absent' || ! \is_int($decoded['time'] ?? null)) {
+            return null;
+        }
+
+        return $decoded['time'];
+    }
+
+    private function wasFlushedAfter(int $tokenTime): bool
+    {
+        $lastFlush = $this->execute(fn () => $this->redis->get($this->getFlushKey()));
+
+        return (\is_int($lastFlush) || \is_string($lastFlush)) && (int) $lastFlush >= $tokenTime;
+    }
+
+    private function deleteIfCurrent(string $key, string $hash, string $value): void
+    {
+        $script = <<<'LUA'
+if redis.call('HGET', KEYS[1], ARGV[1]) == ARGV[2] then
+    redis.call('HDEL', KEYS[1], ARGV[1])
+end
+return 1
+LUA;
+
+        $this->execute(fn () => $this->redis->eval($script, [$key, $hash, $value], 1));
+    }
+
+    private function getFlushKey(): string
+    {
+        return 'utopia-cache-flush-token';
     }
 
     /**

--- a/src/Cache/Adapter/Sharding.php
+++ b/src/Cache/Adapter/Sharding.php
@@ -3,8 +3,10 @@
 namespace Utopia\Cache\Adapter;
 
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Feature\FencedFill;
+use Utopia\Cache\Token;
 
-class Sharding implements Adapter
+class Sharding implements Adapter, FencedFill
 {
     /**
      * @var Adapter[]
@@ -55,6 +57,16 @@ class Sharding implements Adapter
         return $this->getAdapter($key)->load($key, $ttl, $hash);
     }
 
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+    {
+        $adapter = $this->getAdapter($key);
+        if ($adapter instanceof FencedFill) {
+            return $adapter->loadFenced($key, $ttl, $hash);
+        }
+
+        return $adapter->load($key, $ttl, $hash);
+    }
+
     /**
      * @param  string  $key
      * @param  array<int|string, mixed>|string  $data
@@ -64,6 +76,16 @@ class Sharding implements Adapter
     public function save(string $key, array|string $data, string $hash = ''): bool|string|array
     {
         return $this->getAdapter($key)->save($key, $data, $hash);
+    }
+
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+    {
+        $adapter = $this->getAdapter($key);
+        if (! ($adapter instanceof FencedFill)) {
+            return false;
+        }
+
+        return $adapter->saveFenced($key, $data, $token, $hash);
     }
 
     /**

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -226,6 +226,10 @@ class Cache
 
         $start = microtime(true);
         $result = $this->adapter->purge($key, $hash);
+        if ($result) {
+            $effectiveHash = empty($hash) ? $key : $hash;
+            $this->forgetPurgedTokens($key, empty($hash) ? null : $effectiveHash);
+        }
         $duration = microtime(true) - $start;
         $this->getOperationDuration()->record($duration, [
             'operation' => 'purge',
@@ -291,6 +295,36 @@ class Cache
         }
 
         unset($this->tokens[$tokenKey]);
+    }
+
+    private function forgetPurgedTokens(string $key, ?string $hash): void
+    {
+        if ($hash !== null) {
+            $this->forgetToken($this->getTokenKey($key, $hash));
+
+            return;
+        }
+
+        $prefix = $this->tokenGeneration."\0".$key."\0";
+        $context = $this->getCoroutineContext();
+        if ($context !== null) {
+            $contextKey = $this->getTokenContextKey();
+            $tokens = $this->getContextTokens($context, $contextKey);
+            foreach (\array_keys($tokens) as $tokenKey) {
+                if (\str_starts_with($tokenKey, $prefix)) {
+                    unset($tokens[$tokenKey]);
+                }
+            }
+            $context[$contextKey] = $tokens;
+
+            return;
+        }
+
+        foreach (\array_keys($this->tokens) as $tokenKey) {
+            if (\str_starts_with($tokenKey, $prefix)) {
+                unset($this->tokens[$tokenKey]);
+            }
+        }
     }
 
     private function consumeToken(string $tokenKey): ?Token

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -9,6 +9,10 @@ use Utopia\Telemetry\Histogram;
 
 class Cache
 {
+    private const MAX_PENDING_TOKENS = 1024;
+
+    private const TOKEN_CONTEXT_PREFIX = '__utopia_cache_tokens:';
+
     private Adapter $adapter;
 
     /**
@@ -27,6 +31,13 @@ class Cache
      * @var Counter|null
      */
     protected ?Counter $loadResults = null;
+
+    /**
+     * @var array<string, Token>
+     */
+    private array $tokens = [];
+
+    private int $tokenGeneration = 0;
 
     /**
      * Set telemetry adapter. Instruments are created lazily on first use to
@@ -98,9 +109,19 @@ class Cache
     {
         $key = $this->caseSensitive ? $key : \strtolower($key);
         $hash = $this->caseSensitive ? $hash : \strtolower($hash);
+        $effectiveHash = empty($hash) ? $key : $hash;
 
         $start = microtime(true);
-        $result = $this->adapter->load($key, $ttl, $hash);
+        $result = $this->adapter instanceof Feature\FencedFill
+            ? $this->adapter->loadFenced($key, $ttl, $hash)
+            : $this->adapter->load($key, $ttl, $hash);
+        $tokenKey = $this->getTokenKey($key, $effectiveHash);
+        if ($result instanceof Token) {
+            $this->rememberToken($tokenKey, $result);
+            $result = false;
+        } else {
+            $this->forgetToken($tokenKey);
+        }
         $duration = microtime(true) - $start;
         $adapterName = $this->adapter->getName($key);
         $this->getOperationDuration()->record($duration, [
@@ -127,9 +148,16 @@ class Cache
     {
         $key = $this->caseSensitive ? $key : strtolower($key);
         $hash = $this->caseSensitive ? $hash : strtolower($hash);
+        $effectiveHash = empty($hash) ? $key : $hash;
+        $tokenKey = $this->getTokenKey($key, $effectiveHash);
+        $token = $this->consumeToken($tokenKey);
         $start = microtime(true);
 
         try {
+            if ($token !== null && $this->adapter instanceof Feature\FencedFill) {
+                return $this->adapter->saveFenced($key, $data, $token, $hash);
+            }
+
             return $this->adapter->save($key, $data, $hash);
         } finally {
             $duration = microtime(true) - $start;
@@ -216,6 +244,8 @@ class Cache
     {
         $start = microtime(true);
         $result = $this->adapter->flush();
+        $this->tokenGeneration++;
+        $this->clearTokens();
         $duration = microtime(true) - $start;
         $this->getOperationDuration()->record($duration, [
             'operation' => 'flush',
@@ -223,6 +253,128 @@ class Cache
         ]);
 
         return $result;
+    }
+
+    private function getTokenKey(string $key, string $hash): string
+    {
+        return $this->tokenGeneration."\0".$key."\0".$hash;
+    }
+
+    private function rememberToken(string $tokenKey, Token $token): void
+    {
+        $context = $this->getCoroutineContext();
+        if ($context !== null) {
+            $contextKey = $this->getTokenContextKey();
+            $tokens = $this->getContextTokens($context, $contextKey);
+            unset($tokens[$tokenKey]);
+            $tokens[$tokenKey] = $token;
+            $context[$contextKey] = $this->pruneTokens($tokens);
+
+            return;
+        }
+
+        unset($this->tokens[$tokenKey]);
+        $this->tokens[$tokenKey] = $token;
+        $this->tokens = $this->pruneTokens($this->tokens);
+    }
+
+    private function forgetToken(string $tokenKey): void
+    {
+        $context = $this->getCoroutineContext();
+        if ($context !== null) {
+            $contextKey = $this->getTokenContextKey();
+            $tokens = $this->getContextTokens($context, $contextKey);
+            unset($tokens[$tokenKey]);
+            $context[$contextKey] = $tokens;
+
+            return;
+        }
+
+        unset($this->tokens[$tokenKey]);
+    }
+
+    private function consumeToken(string $tokenKey): ?Token
+    {
+        $context = $this->getCoroutineContext();
+        if ($context !== null) {
+            $contextKey = $this->getTokenContextKey();
+            $tokens = $this->getContextTokens($context, $contextKey);
+            $token = $tokens[$tokenKey] ?? null;
+            unset($tokens[$tokenKey]);
+            $context[$contextKey] = $tokens;
+
+            return $token;
+        }
+
+        $token = $this->tokens[$tokenKey] ?? null;
+        unset($this->tokens[$tokenKey]);
+
+        return $token;
+    }
+
+    private function clearTokens(): void
+    {
+        $context = $this->getCoroutineContext();
+        if ($context !== null) {
+            unset($context[$this->getTokenContextKey()]);
+        }
+
+        $this->tokens = [];
+    }
+
+    private function getTokenContextKey(): string
+    {
+        return self::TOKEN_CONTEXT_PREFIX.\spl_object_id($this);
+    }
+
+    /**
+     * @return \ArrayAccess<string, mixed>|null
+     */
+    private function getCoroutineContext(): ?\ArrayAccess
+    {
+        if (! \class_exists(\Swoole\Coroutine::class, false)) {
+            return null;
+        }
+
+        $cid = \call_user_func([\Swoole\Coroutine::class, 'getCid']);
+        if (! \is_int($cid) || $cid < 0) {
+            return null;
+        }
+
+        $context = \call_user_func([\Swoole\Coroutine::class, 'getContext']);
+        if (! $context instanceof \ArrayAccess) {
+            return null;
+        }
+
+        return $context;
+    }
+
+    /**
+     * @param  \ArrayAccess<string, mixed>  $context
+     * @return array<string, Token>
+     */
+    private function getContextTokens(\ArrayAccess $context, string $contextKey): array
+    {
+        if (! isset($context[$contextKey]) || ! \is_array($context[$contextKey])) {
+            return [];
+        }
+
+        /** @var array<string, Token> */
+        return $context[$contextKey];
+    }
+
+    /**
+     * @param  array<string, Token>  $tokens
+     * @return array<string, Token>
+     */
+    private function pruneTokens(array $tokens): array
+    {
+        while (\count($tokens) > self::MAX_PENDING_TOKENS) {
+            $oldest = \array_key_first($tokens);
+            unset($tokens[$oldest]);
+        }
+
+        return $tokens;
     }
 
     /**

--- a/src/Cache/Feature/FencedFill.php
+++ b/src/Cache/Feature/FencedFill.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Utopia\Cache\Feature;
+
+use Utopia\Cache\Token;
+
+interface FencedFill
+{
+    /**
+     * Load cached data and return an internal fill token on cache misses.
+     *
+     * @param  string  $key
+     * @param  int  $ttl time in seconds
+     * @param  string  $hash optional
+     * @return mixed
+     */
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed;
+
+    /**
+     * Save data only if the fill token is still current.
+     *
+     * @param  string  $key
+     * @param  array<int|string, mixed>|string  $data
+     * @param  Token  $token
+     * @param  string  $hash optional
+     * @return bool|string|array<int|string, mixed>
+     */
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array;
+}

--- a/src/Cache/Token.php
+++ b/src/Cache/Token.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Utopia\Cache;
+
+/**
+ * Internal marker used to fence cache fills after misses.
+ */
+final class Token
+{
+    public function __construct(
+        public readonly string $value
+    ) {
+    }
+}

--- a/tests/Cache/E2E/Redis/MultiplexingTest.php
+++ b/tests/Cache/E2E/Redis/MultiplexingTest.php
@@ -154,7 +154,7 @@ class MultiplexingTest extends TestCase
         });
     }
 
-    public function testPurgedMissDoesNotSave(): void
+    public function testPurgedMissAllowsFreshSave(): void
     {
         $this->runCo(function () {
             $cache = $this->makeCache();
@@ -163,8 +163,31 @@ class MultiplexingTest extends TestCase
             $this->assertFalse($cache->load('redis-mux:purged-miss-key', 60, 'redis-mux:purged-miss-key'));
             $cache->purge('redis-mux:purged-miss-key', 'redis-mux:purged-miss-key');
 
-            $this->assertFalse($cache->save('redis-mux:purged-miss-key', 'stale data', 'redis-mux:purged-miss-key'));
-            $this->assertFalse($cache->load('redis-mux:purged-miss-key', 60, 'redis-mux:purged-miss-key'));
+            $this->assertEquals('fresh data', $cache->save('redis-mux:purged-miss-key', 'fresh data', 'redis-mux:purged-miss-key'));
+            $this->assertEquals('fresh data', $cache->load('redis-mux:purged-miss-key', 60, 'redis-mux:purged-miss-key'));
+
+            $cache->purge('redis-mux:purged-miss-key', 'redis-mux:purged-miss-key');
+        });
+    }
+
+    public function testFlushBlocksPreFlushMissToken(): void
+    {
+        $this->runCo(function () {
+            $cache = $this->makeCache();
+            $cache->purge('redis-mux:flush-fence-key', 'redis-mux:flush-fence-key');
+
+            $this->assertFalse($cache->load('redis-mux:flush-fence-key', 60, 'redis-mux:flush-fence-key'));
+
+            $otherAdapter = new RedisMultiplexing('redis', 6379);
+            try {
+                $otherCache = new Cache($otherAdapter);
+                $this->assertTrue($otherCache->flush());
+            } finally {
+                $otherAdapter->disconnect();
+            }
+
+            $this->assertFalse($cache->save('redis-mux:flush-fence-key', 'stale data', 'redis-mux:flush-fence-key'));
+            $this->assertFalse($cache->load('redis-mux:flush-fence-key', 60, 'redis-mux:flush-fence-key'));
         });
     }
 

--- a/tests/Cache/E2E/Redis/MultiplexingTest.php
+++ b/tests/Cache/E2E/Redis/MultiplexingTest.php
@@ -140,6 +140,63 @@ class MultiplexingTest extends TestCase
         });
     }
 
+    public function testMissSaveIsFenced(): void
+    {
+        $this->runCo(function () {
+            $cache = $this->makeCache();
+            $cache->purge('redis-mux:fenced-key', 'redis-mux:fenced-key');
+
+            $this->assertFalse($cache->load('redis-mux:fenced-key', 60, 'redis-mux:fenced-key'));
+            $this->assertEquals('fresh data', $cache->save('redis-mux:fenced-key', 'fresh data', 'redis-mux:fenced-key'));
+            $this->assertEquals('fresh data', $cache->load('redis-mux:fenced-key', 60, 'redis-mux:fenced-key'));
+
+            $cache->purge('redis-mux:fenced-key', 'redis-mux:fenced-key');
+        });
+    }
+
+    public function testPurgedMissDoesNotSave(): void
+    {
+        $this->runCo(function () {
+            $cache = $this->makeCache();
+            $cache->purge('redis-mux:purged-miss-key', 'redis-mux:purged-miss-key');
+
+            $this->assertFalse($cache->load('redis-mux:purged-miss-key', 60, 'redis-mux:purged-miss-key'));
+            $cache->purge('redis-mux:purged-miss-key', 'redis-mux:purged-miss-key');
+
+            $this->assertFalse($cache->save('redis-mux:purged-miss-key', 'stale data', 'redis-mux:purged-miss-key'));
+            $this->assertFalse($cache->load('redis-mux:purged-miss-key', 60, 'redis-mux:purged-miss-key'));
+        });
+    }
+
+    public function testExpiredEntryCanBeReplacedByFencedSave(): void
+    {
+        $this->runCo(function () {
+            $cache = $this->makeCache();
+            $cache->purge('redis-mux:expired-fence-key', 'redis-mux:expired-fence-key');
+            $cache->save('redis-mux:expired-fence-key', 'expired data', 'redis-mux:expired-fence-key');
+
+            $this->assertFalse($cache->load('redis-mux:expired-fence-key', 0, 'redis-mux:expired-fence-key'));
+            $this->assertEquals('fresh data', $cache->save('redis-mux:expired-fence-key', 'fresh data', 'redis-mux:expired-fence-key'));
+            $this->assertEquals('fresh data', $cache->load('redis-mux:expired-fence-key', 60, 'redis-mux:expired-fence-key'));
+
+            $cache->purge('redis-mux:expired-fence-key', 'redis-mux:expired-fence-key');
+        });
+    }
+
+    public function testGlobalPurgeBlocksStaleHashFill(): void
+    {
+        $this->runCo(function () {
+            $cache = $this->makeCache();
+            $cache->purge('redis-mux:global-purge-key');
+
+            $this->assertFalse($cache->load('redis-mux:global-purge-key', 60, 'field'));
+            $cache->purge('redis-mux:global-purge-key');
+
+            $this->assertFalse($cache->save('redis-mux:global-purge-key', 'stale data', 'field'));
+            $this->assertFalse($cache->load('redis-mux:global-purge-key', 60, 'field'));
+        });
+    }
+
     public function testJsonData(): void
     {
         $this->runCo(function () {

--- a/tests/Cache/E2E/Redis/RedisClusterTest.php
+++ b/tests/Cache/E2E/Redis/RedisClusterTest.php
@@ -92,15 +92,31 @@ class RedisClusterTest extends Base
         self::$cache->purge('redis-cluster:fenced-key', 'redis-cluster:fenced-key');
     }
 
-    public function testRedisClusterPurgedMissDoesNotSave(): void
+    public function testRedisClusterPurgedMissAllowsFreshSave(): void
     {
         self::$cache->purge('redis-cluster:purged-miss-key', 'redis-cluster:purged-miss-key');
 
         $this->assertFalse(self::$cache->load('redis-cluster:purged-miss-key', 60, 'redis-cluster:purged-miss-key'));
         self::$cache->purge('redis-cluster:purged-miss-key', 'redis-cluster:purged-miss-key');
 
-        $this->assertFalse(self::$cache->save('redis-cluster:purged-miss-key', 'stale data', 'redis-cluster:purged-miss-key'));
-        $this->assertFalse(self::$cache->load('redis-cluster:purged-miss-key', 60, 'redis-cluster:purged-miss-key'));
+        $this->assertEquals('fresh data', self::$cache->save('redis-cluster:purged-miss-key', 'fresh data', 'redis-cluster:purged-miss-key'));
+        $this->assertEquals('fresh data', self::$cache->load('redis-cluster:purged-miss-key', 60, 'redis-cluster:purged-miss-key'));
+
+        self::$cache->purge('redis-cluster:purged-miss-key', 'redis-cluster:purged-miss-key');
+    }
+
+    public function testRedisClusterFlushBlocksPreFlushMissToken(): void
+    {
+        self::$cache->purge('redis-cluster:flush-fence-key', 'redis-cluster:flush-fence-key');
+
+        $this->assertFalse(self::$cache->load('redis-cluster:flush-fence-key', 60, 'redis-cluster:flush-fence-key'));
+
+        $redis = new RedisCluster(null, SEEDS, TIMEOUT, TIMEOUT);
+        $otherCache = new Cache(new RedisAdapter($redis, SEEDS));
+        $this->assertTrue($otherCache->flush());
+
+        $this->assertFalse(self::$cache->save('redis-cluster:flush-fence-key', 'stale data', 'redis-cluster:flush-fence-key'));
+        $this->assertFalse(self::$cache->load('redis-cluster:flush-fence-key', 60, 'redis-cluster:flush-fence-key'));
     }
 
     public function testRedisClusterExpiredEntryCanBeReplacedByFencedSave(): void

--- a/tests/Cache/E2E/Redis/RedisClusterTest.php
+++ b/tests/Cache/E2E/Redis/RedisClusterTest.php
@@ -80,4 +80,49 @@ class RedisClusterTest extends Base
         $this->assertEquals('reconnect', self::$cache->save('test:reconnect', 'reconnect', 'test:reconnect'));
         $this->assertEquals('reconnect', self::$cache->load('test:reconnect', 5));
     }
+
+    public function testRedisClusterMissSaveIsFenced(): void
+    {
+        self::$cache->purge('redis-cluster:fenced-key', 'redis-cluster:fenced-key');
+
+        $this->assertFalse(self::$cache->load('redis-cluster:fenced-key', 60, 'redis-cluster:fenced-key'));
+        $this->assertEquals('fresh data', self::$cache->save('redis-cluster:fenced-key', 'fresh data', 'redis-cluster:fenced-key'));
+        $this->assertEquals('fresh data', self::$cache->load('redis-cluster:fenced-key', 60, 'redis-cluster:fenced-key'));
+
+        self::$cache->purge('redis-cluster:fenced-key', 'redis-cluster:fenced-key');
+    }
+
+    public function testRedisClusterPurgedMissDoesNotSave(): void
+    {
+        self::$cache->purge('redis-cluster:purged-miss-key', 'redis-cluster:purged-miss-key');
+
+        $this->assertFalse(self::$cache->load('redis-cluster:purged-miss-key', 60, 'redis-cluster:purged-miss-key'));
+        self::$cache->purge('redis-cluster:purged-miss-key', 'redis-cluster:purged-miss-key');
+
+        $this->assertFalse(self::$cache->save('redis-cluster:purged-miss-key', 'stale data', 'redis-cluster:purged-miss-key'));
+        $this->assertFalse(self::$cache->load('redis-cluster:purged-miss-key', 60, 'redis-cluster:purged-miss-key'));
+    }
+
+    public function testRedisClusterExpiredEntryCanBeReplacedByFencedSave(): void
+    {
+        self::$cache->purge('redis-cluster:expired-fence-key', 'redis-cluster:expired-fence-key');
+        self::$cache->save('redis-cluster:expired-fence-key', 'expired data', 'redis-cluster:expired-fence-key');
+
+        $this->assertFalse(self::$cache->load('redis-cluster:expired-fence-key', 0, 'redis-cluster:expired-fence-key'));
+        $this->assertEquals('fresh data', self::$cache->save('redis-cluster:expired-fence-key', 'fresh data', 'redis-cluster:expired-fence-key'));
+        $this->assertEquals('fresh data', self::$cache->load('redis-cluster:expired-fence-key', 60, 'redis-cluster:expired-fence-key'));
+
+        self::$cache->purge('redis-cluster:expired-fence-key', 'redis-cluster:expired-fence-key');
+    }
+
+    public function testRedisClusterGlobalPurgeBlocksStaleHashFill(): void
+    {
+        self::$cache->purge('redis-cluster:global-purge-key');
+
+        $this->assertFalse(self::$cache->load('redis-cluster:global-purge-key', 60, 'field'));
+        self::$cache->purge('redis-cluster:global-purge-key');
+
+        $this->assertFalse(self::$cache->save('redis-cluster:global-purge-key', 'stale data', 'field'));
+        $this->assertFalse(self::$cache->load('redis-cluster:global-purge-key', 60, 'field'));
+    }
 }

--- a/tests/Cache/E2E/Redis/RedisTest.php
+++ b/tests/Cache/E2E/Redis/RedisTest.php
@@ -88,4 +88,49 @@ class RedisTest extends Base
         $this->assertEquals('reconnect_persistent', self::$cache->save('test:reconnect_persistent', 'reconnect_persistent', 'test:reconnect_persistent'));
         $this->assertEquals('reconnect_persistent', self::$cache->load('test:reconnect_persistent', 5));
     }
+
+    public function testRedisMissSaveIsFenced(): void
+    {
+        self::$cache->purge('redis:fenced-key', 'redis:fenced-key');
+
+        $this->assertFalse(self::$cache->load('redis:fenced-key', 60, 'redis:fenced-key'));
+        $this->assertEquals('fresh data', self::$cache->save('redis:fenced-key', 'fresh data', 'redis:fenced-key'));
+        $this->assertEquals('fresh data', self::$cache->load('redis:fenced-key', 60, 'redis:fenced-key'));
+
+        self::$cache->purge('redis:fenced-key', 'redis:fenced-key');
+    }
+
+    public function testRedisPurgedMissDoesNotSave(): void
+    {
+        self::$cache->purge('redis:purged-miss-key', 'redis:purged-miss-key');
+
+        $this->assertFalse(self::$cache->load('redis:purged-miss-key', 60, 'redis:purged-miss-key'));
+        self::$cache->purge('redis:purged-miss-key', 'redis:purged-miss-key');
+
+        $this->assertFalse(self::$cache->save('redis:purged-miss-key', 'stale data', 'redis:purged-miss-key'));
+        $this->assertFalse(self::$cache->load('redis:purged-miss-key', 60, 'redis:purged-miss-key'));
+    }
+
+    public function testRedisExpiredEntryCanBeReplacedByFencedSave(): void
+    {
+        self::$cache->purge('redis:expired-fence-key', 'redis:expired-fence-key');
+        self::$cache->save('redis:expired-fence-key', 'expired data', 'redis:expired-fence-key');
+
+        $this->assertFalse(self::$cache->load('redis:expired-fence-key', 0, 'redis:expired-fence-key'));
+        $this->assertEquals('fresh data', self::$cache->save('redis:expired-fence-key', 'fresh data', 'redis:expired-fence-key'));
+        $this->assertEquals('fresh data', self::$cache->load('redis:expired-fence-key', 60, 'redis:expired-fence-key'));
+
+        self::$cache->purge('redis:expired-fence-key', 'redis:expired-fence-key');
+    }
+
+    public function testRedisGlobalPurgeBlocksStaleHashFill(): void
+    {
+        self::$cache->purge('redis:global-purge-key');
+
+        $this->assertFalse(self::$cache->load('redis:global-purge-key', 60, 'field'));
+        self::$cache->purge('redis:global-purge-key');
+
+        $this->assertFalse(self::$cache->save('redis:global-purge-key', 'stale data', 'field'));
+        $this->assertFalse(self::$cache->load('redis:global-purge-key', 60, 'field'));
+    }
 }

--- a/tests/Cache/E2E/Redis/RedisTest.php
+++ b/tests/Cache/E2E/Redis/RedisTest.php
@@ -100,15 +100,32 @@ class RedisTest extends Base
         self::$cache->purge('redis:fenced-key', 'redis:fenced-key');
     }
 
-    public function testRedisPurgedMissDoesNotSave(): void
+    public function testRedisPurgedMissAllowsFreshSave(): void
     {
         self::$cache->purge('redis:purged-miss-key', 'redis:purged-miss-key');
 
         $this->assertFalse(self::$cache->load('redis:purged-miss-key', 60, 'redis:purged-miss-key'));
         self::$cache->purge('redis:purged-miss-key', 'redis:purged-miss-key');
 
-        $this->assertFalse(self::$cache->save('redis:purged-miss-key', 'stale data', 'redis:purged-miss-key'));
-        $this->assertFalse(self::$cache->load('redis:purged-miss-key', 60, 'redis:purged-miss-key'));
+        $this->assertEquals('fresh data', self::$cache->save('redis:purged-miss-key', 'fresh data', 'redis:purged-miss-key'));
+        $this->assertEquals('fresh data', self::$cache->load('redis:purged-miss-key', 60, 'redis:purged-miss-key'));
+
+        self::$cache->purge('redis:purged-miss-key', 'redis:purged-miss-key');
+    }
+
+    public function testRedisFlushBlocksPreFlushMissToken(): void
+    {
+        self::$cache->purge('redis:flush-fence-key', 'redis:flush-fence-key');
+
+        $this->assertFalse(self::$cache->load('redis:flush-fence-key', 60, 'redis:flush-fence-key'));
+
+        $redis = new Redis();
+        $redis->connect('redis', 6379);
+        $otherCache = new Cache(new RedisAdapter($redis));
+        $this->assertTrue($otherCache->flush());
+
+        $this->assertFalse(self::$cache->save('redis:flush-fence-key', 'stale data', 'redis:flush-fence-key'));
+        $this->assertFalse(self::$cache->load('redis:flush-fence-key', 60, 'redis:flush-fence-key'));
     }
 
     public function testRedisExpiredEntryCanBeReplacedByFencedSave(): void

--- a/tests/Cache/Unit/FencedFillTest.php
+++ b/tests/Cache/Unit/FencedFillTest.php
@@ -167,6 +167,152 @@ class FencedFillTest extends TestCase
         $this->assertCount(1024, $tokens);
     }
 
+    public function testPurgeClearsPendingFillTokenForHash(): void
+    {
+        $adapter = new class implements Adapter, FencedFill
+        {
+            public bool $saveFencedCalled = false;
+
+            public function load(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return false;
+            }
+
+            public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return new Token('token');
+            }
+
+            public function save(string $key, array|string $data, string $hash = ''): bool|string|array
+            {
+                return $data;
+            }
+
+            public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+            {
+                $this->saveFencedCalled = true;
+
+                return false;
+            }
+
+            public function touch(string $key, string $hash = ''): bool
+            {
+                return false;
+            }
+
+            public function list(string $key): array
+            {
+                return [];
+            }
+
+            public function purge(string $key, string $hash = ''): bool
+            {
+                return true;
+            }
+
+            public function flush(): bool
+            {
+                return true;
+            }
+
+            public function ping(): bool
+            {
+                return true;
+            }
+
+            public function getSize(): int
+            {
+                return 0;
+            }
+
+            public function getName(?string $key = null): string
+            {
+                return 'fenced';
+            }
+        };
+        $cache = new Cache($adapter);
+
+        $this->assertFalse($cache->load('key', 60, 'hash'));
+        $this->assertTrue($cache->purge('key', 'hash'));
+
+        $this->assertSame('fresh', $cache->save('key', 'fresh', 'hash'));
+        $this->assertFalse($adapter->saveFencedCalled);
+    }
+
+    public function testKeyPurgeClearsPendingFillTokensForAllHashes(): void
+    {
+        $adapter = new class implements Adapter, FencedFill
+        {
+            public int $saveFencedCalls = 0;
+
+            public function load(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return false;
+            }
+
+            public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return new Token('token-'.$hash);
+            }
+
+            public function save(string $key, array|string $data, string $hash = ''): bool|string|array
+            {
+                return $data;
+            }
+
+            public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+            {
+                $this->saveFencedCalls++;
+
+                return false;
+            }
+
+            public function touch(string $key, string $hash = ''): bool
+            {
+                return false;
+            }
+
+            public function list(string $key): array
+            {
+                return [];
+            }
+
+            public function purge(string $key, string $hash = ''): bool
+            {
+                return true;
+            }
+
+            public function flush(): bool
+            {
+                return true;
+            }
+
+            public function ping(): bool
+            {
+                return true;
+            }
+
+            public function getSize(): int
+            {
+                return 0;
+            }
+
+            public function getName(?string $key = null): string
+            {
+                return 'fenced';
+            }
+        };
+        $cache = new Cache($adapter);
+
+        $this->assertFalse($cache->load('key', 60, 'hash-a'));
+        $this->assertFalse($cache->load('key', 60, 'hash-b'));
+        $this->assertTrue($cache->purge('key'));
+
+        $this->assertSame('fresh-a', $cache->save('key', 'fresh-a', 'hash-a'));
+        $this->assertSame('fresh-b', $cache->save('key', 'fresh-b', 'hash-b'));
+        $this->assertSame(0, $adapter->saveFencedCalls);
+    }
+
     public function testShardingForwardsFencedFill(): void
     {
         $adapter = new FencedTestAdapter();

--- a/tests/Cache/Unit/FencedFillTest.php
+++ b/tests/Cache/Unit/FencedFillTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Utopia\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter;
+use Utopia\Cache\Cache;
+use Utopia\Cache\Feature\FencedFill;
+use Utopia\Cache\Token;
+
+class FencedFillTest extends TestCase
+{
+    public function testSaveUsesPendingFillToken(): void
+    {
+        $adapter = new class implements Adapter, FencedFill
+        {
+            public ?string $loadHash = null;
+
+            public ?string $saveHash = null;
+
+            public ?Token $saveToken = null;
+
+            public function load(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return false;
+            }
+
+            public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+            {
+                $this->loadHash = $hash;
+
+                return new Token('token');
+            }
+
+            public function save(string $key, array|string $data, string $hash = ''): bool|string|array
+            {
+                return false;
+            }
+
+            public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+            {
+                $this->saveHash = $hash;
+                $this->saveToken = $token;
+
+                return $hash === '' && $token->value === 'token' ? $data : false;
+            }
+
+            public function touch(string $key, string $hash = ''): bool
+            {
+                return false;
+            }
+
+            public function list(string $key): array
+            {
+                return [];
+            }
+
+            public function purge(string $key, string $hash = ''): bool
+            {
+                return true;
+            }
+
+            public function flush(): bool
+            {
+                return true;
+            }
+
+            public function ping(): bool
+            {
+                return true;
+            }
+
+            public function getSize(): int
+            {
+                return 0;
+            }
+
+            public function getName(?string $key = null): string
+            {
+                return 'fenced';
+            }
+        };
+
+        $cache = new Cache($adapter);
+
+        $this->assertFalse($cache->load('key', 60));
+        $this->assertSame('value', $cache->save('key', 'value'));
+        $this->assertSame('', $adapter->loadHash);
+        $this->assertSame('', $adapter->saveHash);
+        $this->assertSame('token', $adapter->saveToken?->value);
+    }
+
+    public function testPendingFillTokensAreBounded(): void
+    {
+        $cache = new Cache(new class implements Adapter, FencedFill
+        {
+            public function load(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return false;
+            }
+
+            public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+            {
+                return new Token($key);
+            }
+
+            public function save(string $key, array|string $data, string $hash = ''): bool|string|array
+            {
+                return $data;
+            }
+
+            public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+            {
+                return $data;
+            }
+
+            public function touch(string $key, string $hash = ''): bool
+            {
+                return false;
+            }
+
+            public function list(string $key): array
+            {
+                return [];
+            }
+
+            public function purge(string $key, string $hash = ''): bool
+            {
+                return true;
+            }
+
+            public function flush(): bool
+            {
+                return true;
+            }
+
+            public function ping(): bool
+            {
+                return true;
+            }
+
+            public function getSize(): int
+            {
+                return 0;
+            }
+
+            public function getName(?string $key = null): string
+            {
+                return 'fenced';
+            }
+        });
+
+        for ($i = 0; $i < 1100; $i++) {
+            $cache->load('key-'.$i, 60);
+        }
+
+        $reflection = new \ReflectionProperty(Cache::class, 'tokens');
+
+        /** @var array<string, Token> $tokens */
+        $tokens = $reflection->getValue($cache);
+        $this->assertCount(1024, $tokens);
+    }
+}

--- a/tests/Cache/Unit/FencedFillTest.php
+++ b/tests/Cache/Unit/FencedFillTest.php
@@ -4,9 +4,15 @@ namespace Utopia\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Utopia\Cache\Adapter;
+use Utopia\Cache\Adapter\CircuitBreaker;
+use Utopia\Cache\Adapter\Pool;
+use Utopia\Cache\Adapter\Sharding;
 use Utopia\Cache\Cache;
 use Utopia\Cache\Feature\FencedFill;
 use Utopia\Cache\Token;
+use Utopia\CircuitBreaker\CircuitBreaker as UtopiaCircuitBreaker;
+use Utopia\Pools\Adapter\Stack;
+use Utopia\Pools\Pool as UtopiaPool;
 
 class FencedFillTest extends TestCase
 {
@@ -159,5 +165,98 @@ class FencedFillTest extends TestCase
         /** @var array<string, Token> $tokens */
         $tokens = $reflection->getValue($cache);
         $this->assertCount(1024, $tokens);
+    }
+
+    public function testShardingForwardsFencedFill(): void
+    {
+        $adapter = new FencedTestAdapter();
+        $cache = new Cache(new Sharding([$adapter]));
+
+        $this->assertFalse($cache->load('key', 60));
+        $this->assertSame('value', $cache->save('key', 'value'));
+        $this->assertSame('token-key', $adapter->saveToken?->value);
+    }
+
+    public function testPoolForwardsFencedFill(): void
+    {
+        $adapter = new FencedTestAdapter();
+        $pool = new UtopiaPool(new Stack(), 'test', 1, fn () => $adapter);
+        $cache = new Cache(new Pool($pool));
+
+        $this->assertFalse($cache->load('key', 60));
+        $this->assertSame('value', $cache->save('key', 'value'));
+        $this->assertSame('token-key', $adapter->saveToken?->value);
+    }
+
+    public function testCircuitBreakerForwardsFencedFill(): void
+    {
+        $adapter = new FencedTestAdapter();
+        $cache = new Cache(new CircuitBreaker($adapter, new UtopiaCircuitBreaker()));
+
+        $this->assertFalse($cache->load('key', 60));
+        $this->assertSame('value', $cache->save('key', 'value'));
+        $this->assertSame('token-key', $adapter->saveToken?->value);
+    }
+}
+
+class FencedTestAdapter implements Adapter, FencedFill
+{
+    public ?Token $saveToken = null;
+
+    public function load(string $key, int $ttl, string $hash = ''): mixed
+    {
+        return false;
+    }
+
+    public function loadFenced(string $key, int $ttl, string $hash = ''): mixed
+    {
+        return new Token('token-'.$key);
+    }
+
+    public function save(string $key, array|string $data, string $hash = ''): bool|string|array
+    {
+        return false;
+    }
+
+    public function saveFenced(string $key, array|string $data, Token $token, string $hash = ''): bool|string|array
+    {
+        $this->saveToken = $token;
+
+        return $data;
+    }
+
+    public function touch(string $key, string $hash = ''): bool
+    {
+        return false;
+    }
+
+    public function list(string $key): array
+    {
+        return [];
+    }
+
+    public function purge(string $key, string $hash = ''): bool
+    {
+        return true;
+    }
+
+    public function flush(): bool
+    {
+        return true;
+    }
+
+    public function ping(): bool
+    {
+        return true;
+    }
+
+    public function getSize(): int
+    {
+        return 0;
+    }
+
+    public function getName(?string $key = null): string
+    {
+        return 'fenced-test';
     }
 }


### PR DESCRIPTION
## What

Fixes stale Redis cache fills after invalidation by fencing Redis-backed cache misses internally.

The problematic sequence is:

1. A reader calls `load()` and misses.
2. Another flow writes newer backing data and invalidates the cache with `purge()` or `flush()`.
3. The original reader finishes its stale read and calls `save()`.
4. Without fencing, that stale value can repopulate Redis after invalidation.

This PR keeps the public cache API unchanged. Callers still use `load()`, `save()`, `purge()`, and `flush()` normally; the cache layer tracks an internal token for Redis miss fills and Redis only accepts the follow-up save when that token is still valid.

## Why this is narrow

This intentionally keeps the fix Redis-focused:

- Only concrete Redis adapters create and validate fenced fill tokens: `Redis`, `RedisCluster`, and `Redis\Multiplexing`.
- Non-Redis storage adapters are unchanged.
- `Adapter` remains unchanged; the new behavior is behind a small `Feature\FencedFill` capability.
- `Pool`, `Sharding`, and `CircuitBreaker` only forward `FencedFill` when their inner adapter supports it, so Redis-backed wrapper deployments keep the same protection.
- Public method signatures and return types are unchanged.

## Changes

- Adds internal `Token` and `Feature\FencedFill` types.
- Updates `Cache` to remember fill tokens only when the top-level adapter supports `FencedFill`.
- Stores pending tokens by normalized key/hash and bounds them to 1024 entries.
- Uses Swoole coroutine context for pending tokens when running inside a coroutine, so concurrent coroutine requests do not consume each other’s fill tokens.
- Clears matching pending tokens after successful same-instance `purge()`, including all known hashes for key-level purge.
- Adds Redis Lua scripts for atomic load/token checks, fenced saves, tombstone writes on purge, and tombstone cleanup on normal save.
- Uses short-lived Redis tombstones to reject stale fills after hash-level or key-level purges.
- Writes a short-lived Redis flush marker from Redis-family `flush()` implementations so pre-flush absent tokens cannot save after a flush.
- Expires absent fill tokens using the same TTL window as tombstones and flush markers.
- Keeps Redis Cluster tombstone keys hash-tagged to the same slot as the cache key. Redis Cluster checks the flush marker outside the per-key Lua script to avoid cross-slot Lua access, with a post-write cleanup check if a flush wins the race.
- Adds focused unit coverage for cache token bookkeeping and wrapper forwarding, plus Redis-only E2E coverage for purge and flush fencing scenarios.

## Redis behavior

- Cache hits decode and return existing values.
- Plain adapter `load()` still returns `false` on misses.
- `Cache::load()` receives an internal token on Redis misses and returns `false` to callers.
- `Cache::save()` consumes the matching token and calls `saveFenced()` only for Redis fenced fills.
- Normal Redis saves still work without requiring a token and atomically clear the field tombstone.
- A purge writes a short-lived tombstone, so older miss tokens from other requests/processes cannot repopulate a purged value.
- A successful same-instance purge clears that instance’s pending fill token, so an explicit invalidate-then-save refresh flow can repopulate normally.
- A flush writes a short-lived marker, so absent tokens issued before the flush are rejected for `TOKEN_TTL` seconds.

## Greptile follow-up

Latest Greptile P1s are now handled:

- **Fence Redis flushes**: `Redis::flush()` and `Redis\Multiplexing::flush()` now perform `FLUSHDB` and marker write in one Lua script. `RedisCluster::flush()` writes a marker after flushing masters and `saveFenced()` checks that marker before and after the per-key fenced save.
- **Clear purge tokens**: successful `Cache::purge()` now clears pending local fill tokens for the purged key/hash, or all known hashes for key-level purge.

Earlier Greptile notes:

- Wrapper forwarding: fixed by forwarding `FencedFill` through `Pool`, `Sharding`, and `CircuitBreaker` when supported by the inner adapter.
- Absent token lifetime: fixed by expiring absent fill tokens with `TOKEN_TTL` during fenced saves.
- Coroutine flush tokens: not changed; `flush()` increments the shared token generation, so old coroutine-context tokens are no longer looked up by later saves.
- PHP 8.2 parse error on typed constants: not changed; this repo requires PHP `>=8.3` in `composer.json`.

## Validation

Passed locally:

- `php -l` on all touched PHP files
- `vendor/bin/phpunit --configuration phpunit.xml tests/Cache/Unit`
- `vendor/bin/phpstan analyse --level max src tests --memory-limit 2G`
- `vendor/bin/pint --test ...` on touched files
- Temporary local Redis 7 Docker check for standalone `Redis` flush fencing:
  - verified `FLUSHDB` is accepted inside `EVAL`
  - verified the flush marker survives the flush
  - verified a pre-flush miss token is rejected after another cache instance flushes

Could not run the repo Redis E2E files from this host because the expected Docker DNS names are not resolvable here:

- `redis`
- `redis-cluster`

The Redis E2E attempt failed in setup/connection before assertions ran. Pint passes, but PHP 8.5 emits deprecation noise from Pint’s bundled dependencies.

## Risk

Risk is limited to Redis-backed cache behavior and wrappers around Redis-backed adapters. The main compatibility surface is that Redis `load()`, fenced `save()`, `purge()`, and standalone `flush()` now execute Lua scripts, and Redis invalidations keep short-lived tombstone/flush markers for `TOKEN_TTL` seconds.
