### PR TITLE
ci: matrix tests by adapter as well as PHP version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,18 @@
 name: "Tests"
 
-on: [ pull_request ]
+on: [pull_request]
+
+env:
+  COMPOSE_PROJECT_NAME: cache
+
 jobs:
-  lint:
-    name: Tests
+  build:
+    name: Build (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4', '8.5']
-
+        php: ['8.3', '8.4', '8.5']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -17,12 +21,96 @@ jobs:
 
       - run: git checkout HEAD^2
 
-      - name: Build
-        run: |
-          export PHP_VERSION=${{ matrix.php-versions }}
-          docker compose build
-          docker compose up -d
-          sleep 10
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Run Tests
-        run: docker compose exec tests vendor/bin/phpunit --configuration phpunit.xml tests
+      - name: Build tests image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.php-${{ matrix.php }}
+          tags: cache-tests:${{ matrix.php }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}
+          outputs: type=docker,dest=/tmp/cache-tests-${{ matrix.php }}.tar
+
+      - name: Cache tests image
+        uses: actions/cache@v4
+        with:
+          key: cache-tests-${{ matrix.php }}-${{ github.event.pull_request.head.sha }}
+          path: /tmp/cache-tests-${{ matrix.php }}.tar
+
+  unit:
+    name: Unit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - run: git checkout HEAD^2
+
+      - name: Restore tests image
+        uses: actions/cache@v4
+        with:
+          key: cache-tests-${{ matrix.php }}-${{ github.event.pull_request.head.sha }}
+          path: /tmp/cache-tests-${{ matrix.php }}.tar
+          fail-on-cache-miss: true
+
+      - name: Start container
+        run: |
+          docker load --input /tmp/cache-tests-${{ matrix.php }}.tar
+          PHP_VERSION=${{ matrix.php }} docker compose up -d --no-deps --wait --wait-timeout 180 tests
+
+      - name: Run unit tests
+        run: docker compose exec -T tests vendor/bin/phpunit --configuration phpunit.xml --testsuite unit
+
+  adapter:
+    name: ${{ matrix.adapter.name }} (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+        adapter:
+          - { name: Memory,         suite: memory,         services: '',                     wait: 0 }
+          - { name: None,           suite: none,           services: '',                     wait: 0 }
+          - { name: Filesystem,     suite: filesystem,     services: '',                     wait: 0 }
+          - { name: Pool,           suite: pool,           services: '',                     wait: 0 }
+          - { name: CircuitBreaker, suite: circuitbreaker, services: '',                     wait: 0 }
+          - { name: Telemetry,      suite: telemetry,      services: '',                     wait: 0 }
+          - { name: Memcached,      suite: memcached,      services: 'memcached',            wait: 3 }
+          - { name: Hazelcast,      suite: hazelcast,      services: 'hazelcast',            wait: 30 }
+          - { name: Sharding,       suite: sharding,       services: 'shardA shardB shardC', wait: 0 }
+          - { name: Redis,          suite: redis,          services: 'redis',                wait: 0 }
+          - { name: RedisCluster,   suite: redis-cluster,  services: 'redis-cluster',        wait: 0 }
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - run: git checkout HEAD^2
+
+      - name: Restore tests image
+        uses: actions/cache@v4
+        with:
+          key: cache-tests-${{ matrix.php }}-${{ github.event.pull_request.head.sha }}
+          path: /tmp/cache-tests-${{ matrix.php }}.tar
+          fail-on-cache-miss: true
+
+      - name: Start services
+        run: |
+          docker load --input /tmp/cache-tests-${{ matrix.php }}.tar
+          PHP_VERSION=${{ matrix.php }} docker compose up -d --no-deps --wait --wait-timeout 180 tests ${{ matrix.adapter.services }}
+          if [ "${{ matrix.adapter.wait }}" -gt 0 ]; then sleep ${{ matrix.adapter.wait }}; fi
+
+      - name: Run ${{ matrix.adapter.name }} tests
+        run: docker compose exec -T tests vendor/bin/phpunit --configuration phpunit.xml --testsuite ${{ matrix.adapter.suite }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,16 @@
+name: cache
+
 services:
   tests:
     container_name: tests
+    image: cache-tests:${PHP_VERSION:-8.4}
     build:
       context: .
       dockerfile: Dockerfile.php-${PHP_VERSION:-8.4}
     networks:
       - database
     volumes:
-      - ./phpunit.xml:/usr/code/phpunit.xml
+      - ./phpunit.xml:/usr/src/code/phpunit.xml
       - ./src:/usr/src/code/src
       - ./tests:/usr/src/code/tests
       - /var/run/docker.sock:/var/run/docker.sock
@@ -23,6 +26,11 @@ services:
   redis:
     image: redis:6.0-alpine
     container_name: cache-redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
     networks:
       - database
 
@@ -32,6 +40,12 @@ services:
     hostname: redis-cluster
     environment:
       - IP=redis-cluster
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -p 7000 cluster info | grep -q cluster_state:ok"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
     networks:
       - database
 
@@ -41,29 +55,44 @@ services:
       HZ_NETWORK_MEMCACHEPROTOCOL_ENABLED: "true"
     container_name: hazelcast
     networks:
-      - database  
+      - database
 
   memcached:
     image: memcached:1.6.17-alpine
     container_name: memcached
     networks:
       - database
-  
+
   shardA:
     image: redis:6.0-alpine
     container_name: shardA
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
     networks:
       - database
-  
+
   shardB:
     image: redis:6.0-alpine
     container_name: shardB
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
     networks:
-      - database  
-  
+      - database
+
   shardC:
     image: redis:6.0-alpine
     container_name: shardC
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
     networks:
       - database
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,8 +12,39 @@
         <testsuite name="unit">
             <directory>./tests/Cache/Unit</directory>
         </testsuite>
-        <testsuite name="e2e">
-            <directory>./tests/Cache/E2E</directory>
+        <testsuite name="memory">
+            <file>./tests/Cache/E2E/MemoryTest.php</file>
+        </testsuite>
+        <testsuite name="none">
+            <file>./tests/Cache/E2E/NoneTest.php</file>
+        </testsuite>
+        <testsuite name="filesystem">
+            <file>./tests/Cache/E2E/FilesystemTest.php</file>
+        </testsuite>
+        <testsuite name="pool">
+            <file>./tests/Cache/E2E/PoolTest.php</file>
+        </testsuite>
+        <testsuite name="circuitbreaker">
+            <file>./tests/Cache/E2E/CircuitBreakerTest.php</file>
+        </testsuite>
+        <testsuite name="telemetry">
+            <file>./tests/Cache/E2E/TelemetryTest.php</file>
+        </testsuite>
+        <testsuite name="memcached">
+            <file>./tests/Cache/E2E/MemcachedTest.php</file>
+        </testsuite>
+        <testsuite name="hazelcast">
+            <file>./tests/Cache/E2E/HazelcastTest.php</file>
+        </testsuite>
+        <testsuite name="sharding">
+            <file>./tests/Cache/E2E/ShardingTest.php</file>
+        </testsuite>
+        <testsuite name="redis">
+            <directory>./tests/Cache/E2E/Redis</directory>
+            <exclude>./tests/Cache/E2E/Redis/RedisClusterTest.php</exclude>
+        </testsuite>
+        <testsuite name="redis-cluster">
+            <file>./tests/Cache/E2E/Redis/RedisClusterTest.php</file>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
## What

The test suite ran in **one job per PHP version**, spinning up every backing service at once and rerunning the whole suite. This adds an **adapter axis** so the matrix is now **PHP × adapter** — each adapter runs in its own job, across all PHP versions, starting only the services it needs.

This matches the adapter-matrix pattern used elsewhere in Utopia (e.g. `utopia-php/database`).

## Why

- **Isolation** — a failure points at one adapter, not "the suite".
- **No cross-contamination** — the slow/flaky `redis-cluster` only spins up for the cluster job, so it can't flake Memory/Filesystem/etc.
- **Faster jobs** — most adapters need no service (Memory, None, Filesystem, Pool, CircuitBreaker, Telemetry); they no longer wait on the full stack.

## Changes

- **`phpunit.xml`** — per-adapter testsuites. The `redis` suite is directory-based, so it also covers `MultiplexingTest` (and any future redis-only test) while excluding `RedisClusterTest`, which needs a different service.
- **`docker-compose.yml`**
  - Pin the project name to `cache` (`RedisClusterTest` hardcodes the `cache_database` network).
  - Give the tests image a deterministic tag (`cache-tests:<php>`) for build-once / load-many.
  - Fix the `phpunit.xml` bind-mount path (`/usr/code` → `/usr/src/code`).
  - Add `redis`-family and cluster healthchecks so `--wait` is reliable.
- **`.github/workflows/test.yml`** — a `build` job builds + caches the per-PHP image once; `unit` and per-adapter `adapter` jobs load it and bring up only their own services via `docker compose up --no-deps --wait`.

## Matrix

`build` (3) → `unit` (3) + `adapter` (11 adapters × 3 PHP = 33). `fail-fast: false`.

Adapters: Memory, None, Filesystem, Pool, CircuitBreaker, Telemetry, Memcached, Hazelcast, Sharding, Redis, RedisCluster.

## Verification

Built `cache-tests:8.4` locally and ran each service-backed suite with only its services up:

| Suite | Result |
|---|---|
| memory | OK (8) |
| redis (RedisTest + Multiplexing, cluster excluded) | OK (20) |
| sharding | OK (9) |
| memcached | OK (9) |
| unit | OK (49) |

`--no-deps --wait` confirmed to start only the named services. `redis-cluster` couldn't be exercised locally — its amd64-only image segfaults `redis-cli` under qemu on Apple Silicon — but the healthcheck command is the same `redis-cli` mechanism that the native `redis`/`shard` images pass, and CI runners are amd64.

## Notes

- Independent of #75; once that merges, its `LeasableTest` lands under `tests/Cache/E2E/Redis/` and is picked up by the directory-based `redis` suite automatically — no matrix edit needed.
- The `e2e` aggregate testsuite is replaced by the granular per-adapter suites; running `phpunit` with no `--testsuite` still executes the full set once (no file overlaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)