### PR TITLE
chore(deps)!: upgrade to utopia-php/pools 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-memcached": "*",
         "ext-redis": "*",
         "utopia-php/circuit-breaker": "0.3.*",
-        "utopia-php/pools": "1.*",
+        "utopia-php/pools": "2.*",
         "utopia-php/telemetry": "*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0bbfaba8e8700ddb517078d445cb0ec",
+    "content-hash": "f62bb19e0009779e8eee3e73f4f36efb",
     "packages": [
         {
             "name": "brick/math",
@@ -1931,27 +1931,30 @@
         },
         {
             "name": "utopia-php/pools",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "74ba7dc985c2f629df8cf08ed95507955e3bcf86"
+                "reference": "48905dac1b8f8050c2e07bdda32a018ca33982fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/74ba7dc985c2f629df8cf08ed95507955e3bcf86",
-                "reference": "74ba7dc985c2f629df8cf08ed95507955e3bcf86",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/48905dac1b8f8050c2e07bdda32a018ca33982fc",
+                "reference": "48905dac1b8f8050c2e07bdda32a018ca33982fc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "utopia-php/telemetry": "*"
+                "utopia-php/telemetry": "^0.4"
             },
             "require-dev": {
-                "laravel/pint": "1.*",
-                "phpstan/phpstan": "1.*",
-                "phpunit/phpunit": "11.*",
-                "swoole/ide-helper": "5.1.2"
+                "swoole/ide-helper": "6.*"
+            },
+            "suggest": {
+                "ext-mongodb": "Needed to support MongoDB database pools",
+                "ext-pdo": "Needed to support MariaDB, MySQL or SQLite database pools",
+                "ext-redis": "Needed to support Redis cache pools",
+                "ext-swoole": "Needed to support Swoole based pool adapter"
             },
             "type": "library",
             "autoload": {
@@ -1978,26 +1981,25 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/pools/issues",
-                "source": "https://github.com/utopia-php/pools/tree/1.0.0"
+                "source": "https://github.com/utopia-php/pools/tree/2.0.1"
             },
-            "time": "2026-01-15T12:34:17+00:00"
+            "time": "2026-07-31T12:19:18+00:00"
         },
         {
             "name": "utopia-php/telemetry",
-            "version": "0.2.0",
+            "version": "0.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/telemetry.git",
-                "reference": "9997ebf59bb77920a7223ad73d834a76b09152c3"
+                "reference": "139943bffcd4f6dd8fb9ed247f946a1d151b006a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/9997ebf59bb77920a7223ad73d834a76b09152c3",
-                "reference": "9997ebf59bb77920a7223ad73d834a76b09152c3",
+                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/139943bffcd4f6dd8fb9ed247f946a1d151b006a",
+                "reference": "139943bffcd4f6dd8fb9ed247f946a1d151b006a",
                 "shasum": ""
             },
             "require": {
-                "ext-opentelemetry": "*",
                 "ext-protobuf": "*",
                 "nyholm/psr7": "1.*",
                 "open-telemetry/exporter-otlp": "1.*",
@@ -2006,10 +2008,6 @@
                 "symfony/http-client": "7.*"
             },
             "require-dev": {
-                "laravel/pint": "1.*",
-                "phpbench/phpbench": "1.*",
-                "phpstan/phpstan": "2.*",
-                "phpunit/phpunit": "11.*",
                 "swoole/ide-helper": "6.*"
             },
             "suggest": {
@@ -2026,6 +2024,7 @@
             "license": [
                 "MIT"
             ],
+            "description": "A lite & fast telemetry library, with adapters for OpenTelemetry",
             "keywords": [
                 "framework",
                 "php",
@@ -2033,9 +2032,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/telemetry/issues",
-                "source": "https://github.com/utopia-php/telemetry/tree/0.2.0"
+                "source": "https://github.com/utopia-php/telemetry/tree/0.4.5"
             },
-            "time": "2025-12-17T07:56:38+00:00"
+            "time": "2026-07-08T11:07:25+00:00"
         }
     ],
     "packages-dev": [
@@ -5517,7 +5516,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4",
+        "php": ">=8.3",
         "ext-json": "*",
         "ext-memcached": "*",
         "ext-redis": "*"

--- a/tests/Cache/E2E/PoolTest.php
+++ b/tests/Cache/E2E/PoolTest.php
@@ -19,7 +19,7 @@ class PoolTest extends Base
 
         $pool = new UtopiaPool(new Stack(), 'test', 10, function () use ($path) {
             return new Filesystem($path);
-        });
+        }, timeout: 0.0);
 
         self::$cache = new Cache(new Pool($pool));
     }


### PR DESCRIPTION
Pools 2.0 makes configuration constructor-only and replaces the retry knobs with a single acquisition budget.

`Cache\Adapter\Pool` only ever calls `$pool->use()`, which is unchanged, so the adapter itself needs no edits. The only code change is the pool construction in `PoolTest`, which now passes the required `timeout`.

Needed so that [appwrite/appwrite](https://github.com/appwrite/appwrite) can move to pools 2 — `utopia-php/cache` is one of the packages still pinning `pools 1.*` and blocking resolution.

**Release order:** this one first, then `utopia-php/database`, then `utopia-php/abuse` — each needs the previous published before its lock file can resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)